### PR TITLE
Add `builder ios share` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ temp/
 # Debug files
 debug/
 __debug_bin*
+
+# built binary
+/builder

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Builder is a CLI tool for iOS development without a Mac. It uses GitHub Actions 
 ## Features
 
 - **Build from anywhere**: Build any iOS app (native, Flutter, React Native) via GitHub Actions
+- **Try it on a simulator**: Use your build on an iOS simulator from Windows or Linux
 - **Flutter & React Native dev tools**: Hot reload on real iOS devices from Windows/Linux
 - **Simple setup**: One command to add the workflow to your repo
 - **Code signing**: Optional signing with your certificate and provisioning profile
@@ -50,6 +51,25 @@ builder ios build
 ```
 
 The CLI triggers the workflow and downloads the IPA to `./dist/`.
+
+### 4. Try it on a simulator (optional)
+
+```bash
+builder ios share
+```
+
+Builds the working tree for the iOS simulator and makes that simulator usable
+from the [MobAI](https://mobai.run) app, so you can tap through a build without
+a Mac. It shows up under CI Devices, stays available while you are using it, and
+closes when you release it there or leave it unused (30 minutes by default, use
+`--duration` to change).
+
+Needs MobAI Pro and a `MOBAI_API_KEY` repository secret. Create the key in the
+MobAI app under Account → API Keys, then:
+
+```bash
+gh secret set MOBAI_API_KEY
+```
 
 ## Supported Frameworks
 

--- a/cmd/builder/root.go
+++ b/cmd/builder/root.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/MobAI-App/ios-builder/internal/auth"
@@ -299,6 +301,18 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("  Created: %s\n", workflowPath)
 
+	// Ship the share workflow next to the build one so `builder ios share` needs
+	// no extra setup. Dispatch-only, so it costs nothing until used.
+	shareContent, err := workflow.GetShareWorkflowTemplate()
+	if err != nil {
+		return fmt.Errorf("failed to get simulator workflow template: %w", err)
+	}
+	sharePath := filepath.Join(workflowDir, "ios-share.yml")
+	if err := os.WriteFile(sharePath, shareContent, 0644); err != nil {
+		return fmt.Errorf("failed to write simulator workflow file: %w", err)
+	}
+	fmt.Printf("  Created: %s\n", sharePath)
+
 	// Save config
 	cfg := &config.Config{
 		Project:  projectName,
@@ -342,7 +356,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		fmt.Println("Committing and pushing...")
 
 		// Git add
-		addCmd := exec.Command("git", "add", ".github/workflows/ios-build.yml", "builder.json")
+		addCmd := exec.Command("git", "add", ".github/workflows/ios-build.yml", ".github/workflows/ios-share.yml", "builder.json")
 		if output, err := addCmd.CombinedOutput(); err != nil {
 			fmt.Printf("  Warning: git add failed: %s\n", strings.TrimSpace(string(output)))
 		} else {
@@ -408,6 +422,20 @@ var iosBuildCmd = &cobra.Command{
 	RunE:  runIOSBuild,
 }
 
+var iosShareCmd = &cobra.Command{
+	Use:   "share",
+	Short: "Try this build on a simulator, from the MobAI app",
+	Long: `Builds the working tree for the iOS simulator on GitHub Actions and makes that
+simulator usable from the MobAI app, so a build can be tried by hand without a
+Mac.
+
+The simulator appears in MobAI under CI Devices. It stays available while it is
+being used and closes once it is released there, or left unused for a while.
+
+Requires MobAI Pro and a MOBAI_API_KEY secret in the repository.`,
+	RunE: runIOSShare,
+}
+
 func init() {
 	// Root command setup
 	cobra.OnInitialize(initConfig)
@@ -431,6 +459,11 @@ func init() {
 	iosBuildCmd.Flags().Bool("unsigned", false, "Build unsigned IPA (skip code signing even if configured)")
 	iosBuildCmd.Flags().StringP("remote", "r", "origin", "Git remote to push the working-tree snapshot to")
 	iosCmd.AddCommand(iosBuildCmd)
+
+	// iOS share command flags
+	iosShareCmd.Flags().Duration("duration", 30*time.Minute, "How long the simulator stays available while unused")
+	iosShareCmd.Flags().StringP("remote", "r", "origin", "Git remote to push the working-tree snapshot to")
+	iosCmd.AddCommand(iosShareCmd)
 }
 
 func runIOSBuild(cmd *cobra.Command, args []string) error {
@@ -459,6 +492,48 @@ func runIOSBuild(cmd *cobra.Command, args []string) error {
 		Unsigned:  unsigned,
 		Remote:    remote,
 	})
+}
+
+func runIOSShare(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	duration, _ := cmd.Flags().GetDuration("duration")
+	remote, _ := cmd.Flags().GetString("remote")
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Ctrl+C cancels ctx; Share cancels the run if interrupted before the sim is
+	// shared. After that it has returned and the job outlives the command.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	ghClient, err := getGitHubClient()
+	if err != nil {
+		return err
+	}
+	result, err := build.NewCoordinator(cfg, ghClient).Share(ctx, build.ShareOptions{
+		Duration: duration,
+		Remote:   remote,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("Simulator ready. Open MobAI and find it under CI Devices.")
+	fmt.Println("It closes when you stop its bridge there, or after being left unused.")
+	fmt.Printf("Workflow: %s\n", result.WorkflowURL)
+
+	return nil
 }
 
 func runBuild(ctx context.Context, cfg *config.Config, opts build.BuildOptions) error {

--- a/internal/build/share.go
+++ b/internal/build/share.go
@@ -1,0 +1,152 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MobAI-App/ios-builder/internal/snapshot"
+)
+
+// ShareWorkflowFile is the workflow that builds for the simulator and then
+// makes it usable from the MobAI app.
+const ShareWorkflowFile = "ios-share.yml"
+
+// ShareOptions configures a simulator session.
+type ShareOptions struct {
+	// Duration is how long the simulator stays available while unused. Using
+	// it keeps it open past this.
+	Duration time.Duration
+	Remote   string // git remote to push the working-tree snapshot to
+	Timeout  time.Duration
+}
+
+// ShareResult describes a started session.
+type ShareResult struct {
+	WorkflowURL string
+	RunID       int64
+}
+
+// shareStepName is the workflow step that publishes the simulator. Reaching it
+// is what turns "building" into "go and use it".
+const shareStepName = "Share the simulator"
+
+// sharePublishGrace covers the gap between the share step starting and the
+// device showing up in the app, which polls rather than being pushed to.
+const sharePublishGrace = 30 * time.Second
+
+// Share builds the working tree for the simulator and publishes it to the
+// account's MobAI app, then returns while the job outlives the command.
+func (c *Coordinator) Share(ctx context.Context, opts ShareOptions) (*ShareResult, error) {
+	if opts.Timeout == 0 {
+		opts.Timeout = DefaultTimeout // building can take a while before sharing starts
+	}
+	if opts.Duration == 0 {
+		opts.Duration = 30 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	buildID := uuid.New().String()[:8]
+	c.progress.Start(buildID)
+
+	c.progress.Update(PhaseSnapshot, "Snapshotting working tree...")
+	sha, err := snapshot.Create(ctx, fmt.Sprintf("ios-builder snapshot %s", buildID))
+	if err != nil {
+		c.progress.Error(PhaseSnapshot, err)
+		return nil, fmt.Errorf("failed to snapshot working tree: %w", err)
+	}
+	ref := snapshot.Ref(buildID)
+	if err := snapshot.Push(ctx, opts.Remote, sha, ref); err != nil {
+		c.progress.Error(PhaseSnapshot, err)
+		return nil, fmt.Errorf("failed to push snapshot: %w", err)
+	}
+	// The snapshot ref is left in place: the job checks it out and runs long
+	// after this returns. The next build prunes old refs.
+	c.progress.Complete(PhaseSnapshot, fmt.Sprintf("Pushed %s", sha[:7]))
+
+	c.progress.Update(PhaseTriggering, "Starting the simulator session...")
+	inputs := map[string]string{
+		"build_id":     buildID,
+		"snapshot_ref": ref,
+		"duration":     opts.Duration.String(),
+	}
+	if c.config.IOS.Path != "" {
+		inputs["ios_path"] = c.config.IOS.Path
+	}
+	if c.config.IOS.Scheme != "" {
+		inputs["scheme"] = c.config.IOS.Scheme
+	}
+	if c.config.Flutter.Version != "" {
+		inputs["flutter_version"] = c.config.Flutter.Version
+	}
+	if err := c.github.TriggerWorkflow(ctx, c.config.GitHub.Owner, c.config.GitHub.Repo, ShareWorkflowFile, inputs); err != nil {
+		c.progress.Error(PhaseTriggering, err)
+		return nil, fmt.Errorf("failed to trigger workflow: %w", err)
+	}
+	c.progress.Complete(PhaseTriggering, "Session starting")
+
+	c.progress.Update(PhaseWaitingStart, "Waiting for the runner...")
+	run, err := c.github.PollForWorkflowStart(ctx, c.config.GitHub.Owner, c.config.GitHub.Repo, ShareWorkflowFile, buildID, 2*time.Minute)
+	if err != nil {
+		c.progress.Error(PhaseWaitingStart, err)
+		return nil, fmt.Errorf("workflow failed to start: %w", err)
+	}
+	c.progress.Complete(PhaseWaitingStart, fmt.Sprintf("Running (run #%d)", run.ID))
+	c.progress.SetWorkflowURL(run.HTMLURL)
+
+	c.progress.Update(PhaseBuilding, "Building for the simulator...")
+	if err := c.waitForShareStep(ctx, run.ID); err != nil {
+		// Aborted before the sim was shared (Ctrl+C, timeout, or failed build):
+		// cancel the run so no runner keeps building. A finished run 409s
+		// harmlessly. Fresh context since the caller's was likely just cancelled.
+		cancelCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if cerr := c.github.CancelWorkflowRun(cancelCtx, c.config.GitHub.Owner, c.config.GitHub.Repo, run.ID); cerr == nil {
+			c.progress.Update(PhaseBuilding, "Cancelled the run")
+		}
+		c.progress.Error(PhaseBuilding, err)
+		return nil, err
+	}
+	c.progress.Complete(PhaseBuilding, "Built")
+
+	return &ShareResult{WorkflowURL: run.HTMLURL, RunID: run.ID}, nil
+}
+
+// waitForShareStep follows the run until the publish step starts. A run that
+// ends before then failed to build; the workflow page says why.
+func (c *Coordinator) waitForShareStep(ctx context.Context, runID int64) error {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for the simulator: %w", ctx.Err())
+		case <-ticker.C:
+		}
+
+		step, total, err := c.github.RunningStep(ctx, c.config.GitHub.Owner, c.config.GitHub.Repo, runID)
+		if err == nil && step != nil {
+			c.progress.UpdateStep(step.Name, step.Number, total, time.Since(step.StartedAt))
+			if step.Name == shareStepName {
+				// Sim is publishing now; wait for it to appear before returning.
+				// An interrupt here is "done", not a reason to cancel a live sim.
+				select {
+				case <-ctx.Done():
+				case <-time.After(sharePublishGrace):
+				}
+				return nil
+			}
+			continue
+		}
+
+		// No step running: either between steps, or the run is over.
+		run, rerr := c.github.GetWorkflowRun(ctx, c.config.GitHub.Owner, c.config.GitHub.Repo, runID)
+		if rerr == nil && run.Status == "completed" {
+			return fmt.Errorf("the build finished without sharing a simulator (%s)", run.Conclusion)
+		}
+	}
+}

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -48,6 +48,26 @@ func (c *Client) TriggerWorkflow(ctx context.Context, owner, repo, workflowFile 
 	return nil
 }
 
+// CancelWorkflowRun requests cancellation of a run. Best-effort: a run that has
+// already finished returns 409, which is treated as success (nothing to cancel).
+func (c *Client) CancelWorkflowRun(ctx context.Context, owner, repo string, runID int64) error {
+	path := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/cancel", owner, repo, runID)
+
+	resp, err := c.request(ctx, "POST", path, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// 202 Accepted on success; 409 Conflict when the run already completed.
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to cancel run (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return nil
+}
+
 // GetWorkflowRun retrieves a specific workflow run
 func (c *Client) GetWorkflowRun(ctx context.Context, owner, repo string, runID int64) (*WorkflowRun, error) {
 	path := fmt.Sprintf("/repos/%s/%s/actions/runs/%d", owner, repo, runID)

--- a/internal/workflow/templates.go
+++ b/internal/workflow/templates.go
@@ -23,3 +23,9 @@ func GetTemplate(name string) ([]byte, error) {
 func GetWorkflowTemplate() ([]byte, error) {
 	return GetTemplate("ios-build.yml")
 }
+
+// GetShareWorkflowTemplate returns the workflow that builds for the simulator
+// and then makes that simulator usable from the MobAI app.
+func GetShareWorkflowTemplate() ([]byte, error) {
+	return GetTemplate("ios-share.yml")
+}

--- a/internal/workflow/templates/ios-share.yml
+++ b/internal/workflow/templates/ios-share.yml
@@ -1,0 +1,216 @@
+name: iOS Simulator
+run-name: iOS Simulator ${{ inputs.build_id }}
+
+# Builds the app for the simulator and then makes that simulator usable from
+# the MobAI app, so the build can be tried by hand from a machine that is not a
+# Mac. The job stays alive while the simulator is in use and ends when it is
+# released or left unused.
+#
+# Simulator builds are never signed, so none of the signing setup in
+# ios-build.yml applies here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: 'Unique build identifier'
+        required: true
+        type: string
+      snapshot_ref:
+        description: 'Ref holding the working-tree snapshot to build (empty builds this branch)'
+        required: false
+        type: string
+        default: ''
+      ios_path:
+        description: 'Path to iOS project (e.g., "ios" for React Native)'
+        required: false
+        type: string
+        default: '.'
+      scheme:
+        description: 'Xcode scheme to build (auto-detected if empty)'
+        required: false
+        type: string
+        default: ''
+      duration:
+        description: 'How long the simulator stays available while unused (e.g. 30m)'
+        required: false
+        type: string
+        default: '30m'
+      flutter_version:
+        description: 'Flutter version to use (e.g., 3.24.0). Empty means latest stable.'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  simulator:
+    runs-on: macos-latest
+    # Bounds the session: a simulator nobody released must not hold a runner
+    # indefinitely. Comfortably above the default duration.
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # The dispatch always runs the workflow from the default branch, so the
+      # sources come from a snapshot ref pushed by the CLI instead.
+      - name: Checkout working-tree snapshot
+        if: inputs.snapshot_ref != ''
+        env:
+          SNAPSHOT_REF: ${{ inputs.snapshot_ref }}
+        run: |
+          set -e
+          git fetch --depth=1 origin "+$SNAPSHOT_REF:refs/heads/snapshot"
+          git checkout --force snapshot
+          echo "Building $(git rev-parse --short HEAD)"
+
+      # Starts the simulator booting in the background (cached, so later runs
+      # boot fast) while the app builds.
+      - name: Install mobai-ci + boot simulator
+        uses: MobAI-App/mobai-ci@v1
+        with:
+          boot-sim: true # UDID lands in $MOBAI_SIM_UDID
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Restore DerivedData cache
+        uses: actions/cache/restore@v4
+        with:
+          path: DerivedData
+          key: deriveddata-sim-${{ github.run_id }}
+          restore-keys: |
+            deriveddata-sim-
+
+      - name: Detect project type
+        id: detect
+        run: |
+          if [ -f "pubspec.yaml" ]; then
+            echo "type=flutter" >> $GITHUB_OUTPUT
+          elif [ -f "package.json" ] && grep -q '"expo"' package.json; then
+            echo "type=expo" >> $GITHUB_OUTPUT
+          elif [ -f "package.json" ] && grep -q '"react-native"' package.json; then
+            echo "type=reactnative" >> $GITHUB_OUTPUT
+          else
+            echo "type=native" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate Xcode project (XcodeGen)
+        env:
+          IOS_PATH: ${{ inputs.ios_path }}
+        run: |
+          set -e
+          cd "$IOS_PATH"
+
+          MANIFEST=""
+          for f in project.yml project.yaml; do
+            if [ -f "$f" ] && grep -qE '^targets:' "$f"; then
+              MANIFEST="$f"
+              break
+            fi
+          done
+
+          if [ -z "$MANIFEST" ]; then
+            echo "No XcodeGen manifest — skipping."
+          elif [ -n "$(find . -maxdepth 1 -name '*.xcodeproj' -print -quit)" ]; then
+            echo "Found a committed .xcodeproj — skipping generation."
+          else
+            echo "Found $MANIFEST and no .xcodeproj — generating with XcodeGen."
+            brew install xcodegen
+            xcodegen generate
+          fi
+
+      - name: Setup Flutter
+        if: steps.detect.outputs.type == 'flutter'
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ inputs.flutter_version || '' }}
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        if: steps.detect.outputs.type == 'flutter'
+        run: flutter pub get
+
+      - name: Setup Node.js
+        if: steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install npm dependencies
+        if: steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo'
+        run: npm install
+
+      - name: Build for the simulator
+        id: build
+        env:
+          IOS_PATH: ${{ inputs.ios_path }}
+          SCHEME: ${{ inputs.scheme }}
+          PROJECT_TYPE: ${{ steps.detect.outputs.type }}
+        run: |
+          set -e
+
+          if [ "$PROJECT_TYPE" = "flutter" ]; then
+            # Flutter drives xcodebuild itself and puts the bundle in a known
+            # place, so there is nothing to detect here.
+            flutter build ios --simulator --debug
+            APP_PATH=$(find build/ios/iphonesimulator -maxdepth 1 -name '*.app' -print -quit)
+          else
+            cd "$IOS_PATH"
+
+            WORKSPACE=$(find . -maxdepth 1 -name '*.xcworkspace' -print -quit)
+            PROJECT=$(find . -maxdepth 1 -name '*.xcodeproj' -print -quit)
+
+            if [ -n "$WORKSPACE" ]; then
+              [ -f Podfile ] && (gem install cocoapods --no-document >/dev/null 2>&1 || true) && pod install
+              TARGET_ARGS="-workspace $WORKSPACE"
+              LIST_ARGS="-workspace $WORKSPACE"
+            elif [ -n "$PROJECT" ]; then
+              TARGET_ARGS="-project $PROJECT"
+              LIST_ARGS="-project $PROJECT"
+            else
+              echo "::error::No .xcworkspace or .xcodeproj found in $IOS_PATH"
+              exit 1
+            fi
+
+            if [ -z "$SCHEME" ]; then
+              SCHEME=$(xcodebuild $LIST_ARGS -list 2>/dev/null | grep -A 100 "Schemes:" | tail -n +2 | grep -v -E "^[[:space:]]*Pods-" | head -1 | xargs)
+            fi
+            echo "Scheme: $SCHEME"
+
+            xcodebuild $TARGET_ARGS \
+              -scheme "$SCHEME" \
+              -configuration Debug \
+              -sdk iphonesimulator \
+              -derivedDataPath "$GITHUB_WORKSPACE/DerivedData" \
+              CODE_SIGNING_ALLOWED=NO \
+              build
+
+            APP_PATH=$(find "$GITHUB_WORKSPACE/DerivedData/Build/Products" -maxdepth 2 -name '*.app' -print -quit)
+            cd "$GITHUB_WORKSPACE"
+          fi
+
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::Build produced no .app"
+            exit 1
+          fi
+          echo "Built $APP_PATH"
+          echo "app_path=$APP_PATH" >> $GITHUB_OUTPUT
+
+      # Installs the build on the simulator and publishes it to the MobAI app.
+      # The step (and the job) stay running until the simulator is released
+      # there or goes unused.
+      - name: Share the simulator
+        env:
+          MOBAI_API_KEY: ${{ secrets.MOBAI_API_KEY }}
+        run: |
+          mobai-ci share \
+            --device "$MOBAI_SIM_UDID" \
+            --app "${{ steps.build.outputs.app_path }}" \
+            --duration "${{ inputs.duration }}" \
+            --label "${{ github.repository }} · ${{ inputs.build_id }}" \
+            --wait-device 4m --startup-timeout 5m


### PR DESCRIPTION
Adds `builder ios share`: builds the working tree for the iOS simulator on GitHub Actions and publishes that simulator to the MobAI app (under CI Devices), so a build can be tried by hand without a Mac.

## What it does
- `builder init` now also writes `.github/workflows/ios-share.yml` (dispatch-only, costs nothing until used).
- `builder ios share` snapshots the working tree, triggers the workflow, follows it until the publish step, then returns — the job deliberately outlives the command (the sim stays up until released in MobAI or left unused).
- **Ctrl+C before the sim is shared** cancels the workflow run (`CancelWorkflowRun`), so aborting a build never leaves a runner building for nothing. Once the sim is published, an interrupt is a no-op — the job is meant to outlive the command.

## Notes
- Requires MobAI Pro and a `MOBAI_API_KEY` repository secret.
- Verified end to end against a real repo: build → publish → drive the sim in MobAI → clean teardown.
- `gofmt`, `go vet`, and golangci-lint (v2.12.2, CI-pinned) all clean.