### PR TITLE
Add pkg/ wrappers so other modules can use the build API

### DIFF
--- a/internal/build/coordinator.go
+++ b/internal/build/coordinator.go
@@ -36,12 +36,19 @@ type Coordinator struct {
 	progress *Progress
 }
 
-// NewCoordinator creates a new build coordinator
+// NewCoordinator creates a new build coordinator that reports progress on stdout
 func NewCoordinator(cfg *config.Config, gh *github.Client) *Coordinator {
+	return NewCoordinatorWithOutput(cfg, gh, os.Stdout)
+}
+
+// NewCoordinatorWithOutput creates a coordinator that renders progress to w.
+// Callers embedding the build flow in another program pass their own writer, or
+// io.Discard to silence it.
+func NewCoordinatorWithOutput(cfg *config.Config, gh *github.Client, w io.Writer) *Coordinator {
 	return &Coordinator{
 		config:   cfg,
 		github:   gh,
-		progress: NewProgress(os.Stdout),
+		progress: NewProgress(w),
 	}
 }
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,32 @@
+// Package auth exposes GitHub token storage to code outside this module.
+//
+// GetToken reads the token ios-builder stored; a caller holding a token from
+// elsewhere can skip this package entirely and hand it to github.NewClient.
+package auth
+
+import (
+	"context"
+
+	"github.com/MobAI-App/ios-builder/internal/auth"
+)
+
+// ErrNotAuthenticated indicates no stored authentication token was found.
+var ErrNotAuthenticated = auth.ErrNotAuthenticated
+
+type Token = auth.Token
+
+// Login performs GitHub OAuth Device Code flow authentication, printing the
+// verification URL and code to stdout, and stores the resulting token.
+func Login(ctx context.Context) (*Token, error) {
+	return auth.Login(ctx)
+}
+
+// GetToken retrieves the stored GitHub token from the OS keychain or file storage.
+func GetToken() (string, error) {
+	return auth.GetToken()
+}
+
+// Logout removes the stored GitHub token.
+func Logout() error {
+	return auth.Logout()
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,0 +1,48 @@
+// Package build exposes remote iOS build coordination to code outside this module.
+//
+// Coordinator.Build runs the whole flow: snapshot the working tree, trigger the
+// workflow, poll for the run, download the IPA. Every step after the snapshot
+// uses the Actions API; callers wanting finer control can drive the snapshot
+// and github packages directly.
+package build
+
+import (
+	"io"
+
+	"github.com/MobAI-App/ios-builder/internal/build"
+	"github.com/MobAI-App/ios-builder/pkg/config"
+	"github.com/MobAI-App/ios-builder/pkg/github"
+)
+
+const (
+	// DefaultTimeout is the default build timeout.
+	DefaultTimeout = build.DefaultTimeout
+
+	// WorkflowFile is the workflow that builds an IPA.
+	WorkflowFile = build.WorkflowFile
+
+	// ShareWorkflowFile is the workflow that publishes a simulator to MobAI.
+	ShareWorkflowFile = build.ShareWorkflowFile
+
+	// IPAArtifactName is the name of the IPA artifact uploaded by the workflow.
+	IPAArtifactName = build.IPAArtifactName
+)
+
+type (
+	Coordinator  = build.Coordinator
+	BuildOptions = build.BuildOptions
+	BuildResult  = build.BuildResult
+	ShareOptions = build.ShareOptions
+	ShareResult  = build.ShareResult
+)
+
+// NewCoordinator creates a build coordinator that reports progress on stdout.
+func NewCoordinator(cfg *config.Config, gh *github.Client) *Coordinator {
+	return build.NewCoordinator(cfg, gh)
+}
+
+// NewCoordinatorWithOutput creates a coordinator that renders progress to w.
+// Pass io.Discard to silence it.
+func NewCoordinatorWithOutput(cfg *config.Config, gh *github.Client, w io.Writer) *Coordinator {
+	return build.NewCoordinatorWithOutput(cfg, gh, w)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,32 @@
+// Package config exposes builder.json handling to code outside this module.
+//
+// The implementation lives in internal/config, which Go forbids other modules
+// from importing. This package re-exports it so ios-builder can be consumed as
+// a library. Types are aliases, not wrappers, so values pass between the two
+// packages without conversion.
+package config
+
+import "github.com/MobAI-App/ios-builder/internal/config"
+
+// ConfigFileName is the default configuration file name.
+const ConfigFileName = config.ConfigFileName
+
+// ErrConfigNotFound indicates builder.json was not found.
+var ErrConfigNotFound = config.ErrConfigNotFound
+
+type (
+	Config            = config.Config
+	GitHubConfig      = config.GitHubConfig
+	IOSConfig         = config.IOSConfig
+	FlutterConfig     = config.FlutterConfig
+	WatchConfig       = config.WatchConfig
+	ReactNativeConfig = config.ReactNativeConfig
+	MobAIConfig       = config.MobAIConfig
+	ValidationError   = config.ValidationError
+	Manager           = config.Manager
+)
+
+// NewManager creates a configuration manager rooted at builder.json.
+func NewManager() *Manager {
+	return config.NewManager()
+}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -1,0 +1,35 @@
+// Package github exposes the GitHub REST client to code outside this module.
+package github
+
+import "github.com/MobAI-App/ios-builder/internal/github"
+
+const (
+	// BaseURL is the GitHub API base URL.
+	BaseURL = github.BaseURL
+
+	// APIVersion is the GitHub API version header value.
+	APIVersion = github.APIVersion
+)
+
+type (
+	Client       = github.Client
+	Repository   = github.Repository
+	WorkflowRun  = github.WorkflowRun
+	Job          = github.Job
+	JobStep      = github.JobStep
+	Artifact     = github.Artifact
+	PublicKey    = github.PublicKey
+	APIError     = github.APIError
+	ProgressFunc = github.ProgressFunc
+)
+
+// NewClient creates a GitHub API client authenticated with token.
+func NewClient(token string) *Client {
+	return github.NewClient(token)
+}
+
+// EncryptSecret encrypts a value using NaCl sealed box for GitHub secrets.
+// publicKey should be base64-encoded, as returned by Client.GetPublicKey.
+func EncryptSecret(publicKey, value string) (string, error) {
+	return github.EncryptSecret(publicKey, value)
+}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -1,0 +1,33 @@
+// Package snapshot exposes working-tree snapshotting to code outside this module.
+//
+// Push takes the target ref as a parameter, so callers are not limited to the
+// namespace Ref returns.
+package snapshot
+
+import (
+	"context"
+
+	"github.com/MobAI-App/ios-builder/internal/snapshot"
+)
+
+// Ref returns the remote ref that holds the snapshot for a build.
+func Ref(buildID string) string {
+	return snapshot.Ref(buildID)
+}
+
+// Create commits the working tree, including staged, unstaged and untracked
+// files, and returns the commit SHA. HEAD, the current branch and the index are
+// left untouched.
+func Create(ctx context.Context, message string) (string, error) {
+	return snapshot.Create(ctx, message)
+}
+
+// Push publishes a snapshot commit to ref on the remote.
+func Push(ctx context.Context, remote, sha, ref string) error {
+	return snapshot.Push(ctx, remote, sha, ref)
+}
+
+// Delete removes ref from the remote.
+func Delete(ctx context.Context, remote, ref string) error {
+	return snapshot.Delete(ctx, remote, ref)
+}

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -1,0 +1,20 @@
+// Package workflow exposes the embedded GitHub Actions templates to code
+// outside this module.
+package workflow
+
+import "github.com/MobAI-App/ios-builder/internal/workflow"
+
+// GetTemplate returns the named embedded template.
+func GetTemplate(name string) ([]byte, error) {
+	return workflow.GetTemplate(name)
+}
+
+// GetWorkflowTemplate returns the iOS build workflow (ios-build.yml).
+func GetWorkflowTemplate() ([]byte, error) {
+	return workflow.GetWorkflowTemplate()
+}
+
+// GetShareWorkflowTemplate returns the simulator share workflow (ios-share.yml).
+func GetShareWorkflowTemplate() ([]byte, error) {
+	return workflow.GetShareWorkflowTemplate()
+}


### PR DESCRIPTION
## Why

Everything in this repo lives under `internal/`, which Go forbids other modules from importing. That means ios-builder can only be consumed as a CLI — there is no way to drive a build from Go code in another module.

This adds a `pkg/` tree that re-exports the pieces needed to do that.

## Approach

Types are **aliases** (`type Config = config.Config`) rather than new named types, so:

- values pass between `pkg/` and `internal/` with no conversion
- methods and struct literals work unchanged
- there is no second copy of anything to keep in sync

Functions are thin wrappers preserving the original signatures.

Exported: `config`, `auth`, `github`, `snapshot`, `build`, `workflow` — the build path only. `dev` and `mobai` are deliberately left out and can follow if a need appears.

## One behavioural addition

`build.NewCoordinator` hardcoded `os.Stdout` for progress rendering, which a caller embedding the flow in another program cannot redirect or silence. Added `NewCoordinatorWithOutput(cfg, gh, w io.Writer)`; `NewCoordinator` now delegates to it with `os.Stdout` and is otherwise unchanged. Nothing about existing CLI behaviour differs.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `gofmt` clean
- Built and **ran** a throwaway external module (its own `go.mod`, `replace`-ing this one) that imports all six `pkg/` packages, builds nested config literals through the aliases, constructs a coordinator with `io.Discard`, and reads the embedded workflow template — confirming the exports genuinely work from outside the module, which compiling in-tree does not prove
- Negative control: that same external module fails with `use of internal package ... not allowed` when importing `internal/config` directly, confirming the wrapper layer is doing real work

Note for reviewers: `golangci-lint` panics on `internal/auth`, `internal/github` and `internal/build` on this machine. That reproduces on `main` with these changes reverted — it is golangci-lint 2.5.0 (built with go1.25.1) against a go1.26.4 toolchain, not something introduced here.