### PR TITLE
Signing without a Mac: generate the CSR and assemble the .p12 in builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ internal/
   auth/              # GitHub OAuth device flow + keyring storage
   github/            # GitHub REST API (workflow dispatch, artifacts)
   build/             # Build coordination (snapshot + trigger + poll + download)
+  signing/           # CSR generation and .p12 assembly (signing without a Mac)
   snapshot/          # Working-tree snapshot as a throwaway commit on a remote ref
   workflow/          # Workflow template (embedded)
   config/            # builder.json management

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ builder dev flutter --skip-install --bundle-id <id>  # Use already installed app
 builder dev rn --metro-port 8082  # Use custom Metro port
 
 # Code signing
-builder signing csr           # Create a certificate signing request (no Mac needed)
-builder signing setup         # Set up code signing secrets
+builder signing csr           # Create a private key + certificate signing request
+builder signing p12           # Assemble a .p12 from the key and Apple's certificate
+builder signing setup         # Upload code signing secrets to GitHub
 ```
 
 ## Configuration
@@ -235,7 +236,18 @@ gitignored files are also excluded from build snapshots).
 2. Choose **Apple Development** (installs on registered devices) or **Apple Distribution** (App Store/Ad Hoc)
 3. Upload `ios-signing.csr` and download the resulting `.cer` file
 
-### 3. Create a provisioning profile
+### 3. Assemble the .p12
+
+```bash
+builder signing p12 --certificate development.cer --key ios-signing.key
+```
+
+This combines the key and certificate into `ios-signing.p12`, protected by a
+password you choose — byte-for-byte the same kind of file Keychain Access
+exports, and usable anywhere one is: `builder signing setup`, Sideloadly,
+AltStore, or importing it on a Mac. Keep it, and don't commit it.
+
+### 4. Create a provisioning profile
 
 On the portal:
 
@@ -243,23 +255,20 @@ On the portal:
 2. **Devices** → register your device's UDID (shown in [MobAI](https://mobai.run) when the device is connected; on Windows, iTunes shows it when you click the serial number on the device page)
 3. **Profiles** → create an **iOS App Development** (or Ad Hoc) profile, select your App ID, certificate, and devices, then download the `.mobileprovision` file
 
-### 4. Upload the signing secrets
+### 5. Upload the signing secrets
 
 ```bash
-builder signing setup --certificate ios_development.cer --key ios-signing.key --profile MyApp.mobileprovision
+builder signing setup --certificate ios-signing.p12 --profile MyApp.mobileprovision
 ```
 
-Builder assembles `ios-signing.p12` from the `.cer` and your key, protected
-with a password you choose — it's your signing identity, reusable with other
-tools (Sideloadly, a Mac, re-running setup), so keep it and don't commit it.
-It then uploads the signing material to GitHub Secrets:
+This uploads the signing material to GitHub Secrets:
 - `IOS_CERTIFICATE` - Base64-encoded .p12 file
 - `IOS_CERTIFICATE_PASSWORD` - Certificate password
 - `IOS_PROVISIONING_PROFILE` - Base64-encoded .mobileprovision file
 
-If you already have a `.p12` (for example, exported from a Mac's Keychain
-Access), pass it directly — `builder signing setup --certificate cert.p12` —
-and you'll be prompted for its password instead.
+You can also skip step 3 and hand `setup` the `.cer` together with the key —
+`builder signing setup --certificate development.cer --key ios-signing.key
+--profile MyApp.mobileprovision` — and it assembles the `.p12` on the way.
 
 Once configured, `builder ios build` will produce signed IPAs. Use `--unsigned` to skip signing.
 

--- a/README.md
+++ b/README.md
@@ -248,8 +248,10 @@ On the portal:
 builder signing setup --certificate ios_development.cer --profile MyApp.mobileprovision
 ```
 
-Builder assembles the `.p12` from the `.cer` and the stored key, and uploads
-the signing material to GitHub Secrets:
+Builder assembles the `.p12` from the `.cer` and the stored key, protects it
+with a password you choose, and saves it to `~/.config/ios-builder/signing.p12`
+— it's your signing identity, reusable with other tools (Sideloadly, a Mac,
+re-running setup). It then uploads the signing material to GitHub Secrets:
 - `IOS_CERTIFICATE` - Base64-encoded .p12 file
 - `IOS_CERTIFICATE_PASSWORD` - Certificate password
 - `IOS_PROVISIONING_PROFILE` - Base64-encoded .mobileprovision file

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ builder dev flutter --skip-install --bundle-id <id>  # Use already installed app
 builder dev rn --metro-port 8082  # Use custom Metro port
 
 # Code signing
+builder signing csr           # Create a certificate signing request (no Mac needed)
 builder signing setup         # Set up code signing secrets
 ```
 
@@ -205,16 +206,57 @@ hostname.exe
 
 ## Code Signing
 
-By default, builds are unsigned. To enable code signing:
+By default, builds are unsigned. Signed builds need a signing certificate and a
+provisioning profile — and despite what many guides claim, **you do not need a
+Mac to create either one**. The `.p12` certificate is normally created through
+Keychain Access, but Builder does the same thing itself: it generates the
+private key and certificate signing request, and assembles the `.p12` from the
+certificate Apple issues.
+
+You need a paid [Apple Developer Program](https://developer.apple.com/programs/)
+membership — the portal only issues certificates to paid accounts. (Without one,
+build unsigned and let [MobAI](https://mobai.run) re-sign on install with a free
+Apple ID.)
+
+### 1. Create a certificate signing request
 
 ```bash
-builder signing setup
+builder signing csr
 ```
 
-This uploads your certificate and provisioning profile to GitHub Secrets:
+This asks for your name and email, stores a private key in Builder's config
+directory (`~/.config/ios-builder/` — outside the repository, so it can never
+end up in a commit or build snapshot), and writes `ios-signing.csr`.
+
+### 2. Create the certificate
+
+1. Go to [Certificates](https://developer.apple.com/account/resources/certificates/add) on the Apple Developer portal
+2. Choose **Apple Development** (installs on registered devices) or **Apple Distribution** (App Store/Ad Hoc)
+3. Upload `ios-signing.csr` and download the resulting `.cer` file
+
+### 3. Create a provisioning profile
+
+On the portal:
+
+1. **Identifiers** → register an App ID matching your app's bundle identifier
+2. **Devices** → register your device's UDID (shown in [MobAI](https://mobai.run) when the device is connected; on Windows, iTunes shows it when you click the serial number on the device page)
+3. **Profiles** → create an **iOS App Development** (or Ad Hoc) profile, select your App ID, certificate, and devices, then download the `.mobileprovision` file
+
+### 4. Upload the signing secrets
+
+```bash
+builder signing setup --certificate ios_development.cer --profile MyApp.mobileprovision
+```
+
+Builder assembles the `.p12` from the `.cer` and the stored key, and uploads
+the signing material to GitHub Secrets:
 - `IOS_CERTIFICATE` - Base64-encoded .p12 file
 - `IOS_CERTIFICATE_PASSWORD` - Certificate password
 - `IOS_PROVISIONING_PROFILE` - Base64-encoded .mobileprovision file
+
+If you already have a `.p12` (for example, exported from a Mac's Keychain
+Access), pass it directly — `builder signing setup --certificate cert.p12` —
+and you'll be prompted for its password instead.
 
 Once configured, `builder ios build` will produce signed IPAs. Use `--unsigned` to skip signing.
 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,10 @@ Apple ID.)
 builder signing csr
 ```
 
-This asks for your name and email, stores a private key in Builder's config
-directory (`~/.config/ios-builder/` — outside the repository, so it can never
-end up in a commit or build snapshot), and writes `ios-signing.csr`.
+This asks for your name and email and writes two files to the current
+directory: `ios-signing.key` (your private key) and `ios-signing.csr`. Keep
+the key wherever suits you — just don't commit it (add it to `.gitignore`;
+gitignored files are also excluded from build snapshots).
 
 ### 2. Create the certificate
 
@@ -245,13 +246,13 @@ On the portal:
 ### 4. Upload the signing secrets
 
 ```bash
-builder signing setup --certificate ios_development.cer --profile MyApp.mobileprovision
+builder signing setup --certificate ios_development.cer --key ios-signing.key --profile MyApp.mobileprovision
 ```
 
-Builder assembles the `.p12` from the `.cer` and the stored key, protects it
-with a password you choose, and saves it to `~/.config/ios-builder/signing.p12`
-— it's your signing identity, reusable with other tools (Sideloadly, a Mac,
-re-running setup). It then uploads the signing material to GitHub Secrets:
+Builder assembles `ios-signing.p12` from the `.cer` and your key, protected
+with a password you choose — it's your signing identity, reusable with other
+tools (Sideloadly, a Mac, re-running setup), so keep it and don't commit it.
+It then uploads the signing material to GitHub Secrets:
 - `IOS_CERTIFICATE` - Base64-encoded .p12 file
 - `IOS_CERTIFICATE_PASSWORD` - Certificate password
 - `IOS_PROVISIONING_PROFILE` - Base64-encoded .mobileprovision file

--- a/cmd/builder/signing.go
+++ b/cmd/builder/signing.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/MobAI-App/ios-builder/internal/auth"
 	"github.com/MobAI-App/ios-builder/internal/config"
 	"github.com/MobAI-App/ios-builder/internal/github"
 	"github.com/MobAI-App/ios-builder/internal/signing"
@@ -28,9 +27,9 @@ var signingSetupCmd = &cobra.Command{
 
 The certificate can be either:
 - A .p12 file (exported from Keychain Access on a Mac)
-- A .cer file downloaded from the Apple Developer portal, if the CSR was
-  created with 'builder signing csr' — the .p12 is then assembled locally,
-  so no Mac is needed at any point
+- A .cer file downloaded from the Apple Developer portal, together with the
+  private key from 'builder signing csr' (--key) — the .p12 is then assembled
+  locally, so no Mac is needed at any point
 
 This command will:
 - Read your certificate and .mobileprovision provisioning profile
@@ -50,10 +49,10 @@ var signingCSRCmd = &cobra.Command{
 	Long: `Creates a private key and a certificate signing request (CSR) for the
 Apple Developer portal — the same thing Keychain Access does on a Mac.
 
-The private key is stored in your builder config directory (outside the
-repository). The CSR is written to ios-signing.csr in the current directory;
-upload it at developer.apple.com to create a certificate, then run
-'builder signing setup --certificate <downloaded>.cer'.`,
+Writes ios-signing.key and ios-signing.csr to the current directory. Keep the
+key private and do not commit it. Upload the CSR at developer.apple.com to
+create a certificate, then run:
+'builder signing setup --certificate <downloaded>.cer --key ios-signing.key'.`,
 	RunE: runSigningCSR,
 }
 
@@ -63,20 +62,10 @@ func init() {
 
 	signingSetupCmd.Flags().StringP("certificate", "c", "", "Path to certificate file (.p12, or .cer from the Apple Developer portal)")
 	signingSetupCmd.Flags().StringP("profile", "p", "", "Path to .mobileprovision file")
+	signingSetupCmd.Flags().StringP("key", "k", "", "Path to the private key from 'builder signing csr' (required with a .cer)")
 
 	signingCSRCmd.Flags().String("name", "", "Your name (certificate common name)")
 	signingCSRCmd.Flags().String("email", "", "Email address of your Apple Developer account")
-}
-
-// signingKeyPath returns where 'signing csr' stores the private key. It lives
-// in the config directory, not the repository, so working-tree snapshots and
-// commits can never pick it up.
-func signingKeyPath() (string, error) {
-	dir, err := auth.ConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "signing.key"), nil
 }
 
 func runSigningCSR(cmd *cobra.Command, args []string) error {
@@ -98,12 +87,10 @@ func runSigningCSR(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name and email are required")
 	}
 
-	keyPath, err := signingKeyPath()
-	if err != nil {
-		return err
-	}
+	keyPath := "ios-signing.key"
+	csrPath := "ios-signing.csr"
 	if _, err := os.Stat(keyPath); err == nil {
-		fmt.Println("A signing key already exists. Regenerating it invalidates any")
+		fmt.Printf("%s already exists. Regenerating it invalidates any\n", keyPath)
 		fmt.Println("certificate created from the previous CSR.")
 		confirm := promptui.Prompt{Label: "Generate a new key", IsConfirm: true}
 		if _, err := confirm.Run(); err != nil {
@@ -116,14 +103,9 @@ func runSigningCSR(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(keyPath), 0700); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
-	}
 	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
 		return fmt.Errorf("failed to write private key: %w", err)
 	}
-
-	csrPath := "ios-signing.csr"
 	if err := os.WriteFile(csrPath, csrPEM, 0644); err != nil {
 		return fmt.Errorf("failed to write CSR: %w", err)
 	}
@@ -132,11 +114,13 @@ func runSigningCSR(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Private key: %s\n", keyPath)
 	fmt.Printf("CSR:         %s\n", csrPath)
 	fmt.Println()
+	fmt.Println("Keep the private key safe and do not commit it (add it to .gitignore).")
+	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  1. Go to https://developer.apple.com/account/resources/certificates/add")
 	fmt.Println("  2. Choose 'Apple Development' (or 'Apple Distribution' for App Store)")
 	fmt.Printf("  3. Upload %s and download the certificate (.cer)\n", csrPath)
-	fmt.Println("  4. Run: builder signing setup --certificate <downloaded>.cer")
+	fmt.Printf("  4. Run: builder signing setup --certificate <downloaded>.cer --key %s\n", keyPath)
 
 	return nil
 }
@@ -217,17 +201,18 @@ func runSigningSetup(cmd *cobra.Command, args []string) error {
 	var password string
 	if isPortalCertificate(certPath) {
 		// A .cer from the Apple Developer portal: assemble the .p12 locally
-		// from the key created by 'builder signing csr'.
-		keyPath, err := signingKeyPath()
-		if err != nil {
-			return err
+		// from the private key that produced the CSR.
+		keyPath, _ := cmd.Flags().GetString("key")
+		if keyPath == "" {
+			keyPath, err = promptString("Path to private key file (from 'builder signing csr')", "ios-signing.key")
+			if err != nil {
+				return err
+			}
 		}
+		keyPath = expandPath(keyPath)
 		keyPEM, err := os.ReadFile(keyPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("no signing key found. The .cer must come from a CSR created with: builder signing csr")
-			}
-			return fmt.Errorf("failed to read signing key: %w", err)
+			return fmt.Errorf("failed to read private key %s: %w", keyPath, err)
 		}
 		passwordPrompt := promptui.Prompt{
 			Label: "Password to protect the .p12",
@@ -244,13 +229,13 @@ func runSigningSetup(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		// Keep the .p12 next to the key: it is the reusable signing identity
-		// (Sideloadly, another machine, re-running setup), not a throwaway.
-		p12Path := filepath.Join(filepath.Dir(keyPath), "signing.p12")
+		// Save the .p12: it is the reusable signing identity (Sideloadly,
+		// another machine, re-running setup), not a throwaway.
+		p12Path := "ios-signing.p12"
 		if err := os.WriteFile(p12Path, certData, 0600); err != nil {
 			return fmt.Errorf("failed to write .p12: %w", err)
 		}
-		fmt.Printf("Assembled .p12 and saved it to %s\n", p12Path)
+		fmt.Printf("Assembled .p12: %s (do not commit it)\n", p12Path)
 	} else {
 		// Get certificate password (no echo)
 		passwordPrompt := promptui.Prompt{

--- a/cmd/builder/signing.go
+++ b/cmd/builder/signing.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/MobAI-App/ios-builder/internal/auth"
 	"github.com/MobAI-App/ios-builder/internal/config"
 	"github.com/MobAI-App/ios-builder/internal/github"
+	"github.com/MobAI-App/ios-builder/internal/signing"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
@@ -24,9 +27,14 @@ var signingSetupCmd = &cobra.Command{
 	Short: "Set up code signing for iOS builds",
 	Long: `Uploads your iOS signing certificate and provisioning profile to GitHub Secrets.
 
+The certificate can be either:
+- A .p12 file (exported from Keychain Access on a Mac)
+- A .cer file downloaded from the Apple Developer portal, if the CSR was
+  created with 'builder signing csr' — the .p12 is then assembled locally,
+  so no Mac is needed at any point
+
 This command will:
-- Read your .p12 certificate file
-- Read your .mobileprovision provisioning profile
+- Read your certificate and .mobileprovision provisioning profile
 - Base64 encode and encrypt them
 - Upload them as GitHub repository secrets:
   - IOS_CERTIFICATE
@@ -37,11 +45,119 @@ After setup, builds will be signed automatically.`,
 	RunE: runSigningSetup,
 }
 
+var signingCSRCmd = &cobra.Command{
+	Use:   "csr",
+	Short: "Create a certificate signing request (no Mac needed)",
+	Long: `Creates a private key and a certificate signing request (CSR) for the
+Apple Developer portal — the same thing Keychain Access does on a Mac.
+
+The private key is stored in your builder config directory (outside the
+repository). The CSR is written to ios-signing.csr in the current directory;
+upload it at developer.apple.com to create a certificate, then run
+'builder signing setup --certificate <downloaded>.cer'.`,
+	RunE: runSigningCSR,
+}
+
 func init() {
 	signingCmd.AddCommand(signingSetupCmd)
+	signingCmd.AddCommand(signingCSRCmd)
 
-	signingSetupCmd.Flags().StringP("certificate", "c", "", "Path to .p12 certificate file")
+	signingSetupCmd.Flags().StringP("certificate", "c", "", "Path to certificate file (.p12, or .cer from the Apple Developer portal)")
 	signingSetupCmd.Flags().StringP("profile", "p", "", "Path to .mobileprovision file")
+
+	signingCSRCmd.Flags().String("name", "", "Your name (certificate common name)")
+	signingCSRCmd.Flags().String("email", "", "Email address of your Apple Developer account")
+}
+
+// signingKeyPath returns where 'signing csr' stores the private key. It lives
+// in the config directory, not the repository, so working-tree snapshots and
+// commits can never pick it up.
+func signingKeyPath() (string, error) {
+	dir, err := auth.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "signing.key"), nil
+}
+
+func runSigningCSR(cmd *cobra.Command, args []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	email, _ := cmd.Flags().GetString("email")
+
+	var err error
+	if name == "" {
+		if name, err = promptString("Your name (as on the certificate)", ""); err != nil {
+			return err
+		}
+	}
+	if email == "" {
+		if email, err = promptString("Apple Developer account email", ""); err != nil {
+			return err
+		}
+	}
+	if name == "" || email == "" {
+		return fmt.Errorf("name and email are required")
+	}
+
+	keyPath, err := signingKeyPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(keyPath); err == nil {
+		fmt.Println("A signing key already exists. Regenerating it invalidates any")
+		fmt.Println("certificate created from the previous CSR.")
+		confirm := promptui.Prompt{Label: "Generate a new key", IsConfirm: true}
+		if _, err := confirm.Run(); err != nil {
+			return fmt.Errorf("keeping the existing key")
+		}
+	}
+
+	keyPEM, csrPEM, err := signing.GenerateKeyAndCSR(name, email)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return fmt.Errorf("failed to write private key: %w", err)
+	}
+
+	csrPath := "ios-signing.csr"
+	if err := os.WriteFile(csrPath, csrPEM, 0644); err != nil {
+		return fmt.Errorf("failed to write CSR: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Printf("Private key: %s\n", keyPath)
+	fmt.Printf("CSR:         %s\n", csrPath)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Go to https://developer.apple.com/account/resources/certificates/add")
+	fmt.Println("  2. Choose 'Apple Development' (or 'Apple Distribution' for App Store)")
+	fmt.Printf("  3. Upload %s and download the certificate (.cer)\n", csrPath)
+	fmt.Println("  4. Run: builder signing setup --certificate <downloaded>.cer")
+
+	return nil
+}
+
+// isPortalCertificate reports whether the path looks like a certificate from
+// the Apple Developer portal rather than a ready-made .p12 bundle.
+func isPortalCertificate(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".cer", ".crt", ".pem":
+		return true
+	}
+	return false
+}
+
+func randomPassword() (string, error) {
+	buf := make([]byte, 18)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
 // expandPath normalizes a path typed at a prompt. The shell never sees these,
@@ -107,17 +223,43 @@ func runSigningSetup(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Profile: %s (%.1f KB)\n", profilePath, float64(len(profileData))/1024)
 
-	// Get certificate password (no echo)
-	passwordPrompt := promptui.Prompt{
-		Label: "Certificate password",
-		Mask:  '*',
-	}
-	password, err := passwordPrompt.Run()
-	if err != nil {
-		return fmt.Errorf("failed to read password: %w", err)
-	}
-	if password == "" {
-		return fmt.Errorf("certificate password is required")
+	var password string
+	if isPortalCertificate(certPath) {
+		// A .cer from the Apple Developer portal: assemble the .p12 locally
+		// from the key created by 'builder signing csr'.
+		keyPath, err := signingKeyPath()
+		if err != nil {
+			return err
+		}
+		keyPEM, err := os.ReadFile(keyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("no signing key found. The .cer must come from a CSR created with: builder signing csr")
+			}
+			return fmt.Errorf("failed to read signing key: %w", err)
+		}
+		password, err = randomPassword()
+		if err != nil {
+			return fmt.Errorf("failed to generate password: %w", err)
+		}
+		certData, err = signing.BuildP12(keyPEM, certData, password)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Assembled .p12 from certificate and signing key")
+	} else {
+		// Get certificate password (no echo)
+		passwordPrompt := promptui.Prompt{
+			Label: "Certificate password",
+			Mask:  '*',
+		}
+		password, err = passwordPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("failed to read password: %w", err)
+		}
+		if password == "" {
+			return fmt.Errorf("certificate password is required")
+		}
 	}
 
 	fmt.Println()

--- a/cmd/builder/signing.go
+++ b/cmd/builder/signing.go
@@ -52,13 +52,26 @@ Apple Developer portal — the same thing Keychain Access does on a Mac.
 Writes ios-signing.key and ios-signing.csr to the current directory. Keep the
 key private and do not commit it. Upload the CSR at developer.apple.com to
 create a certificate, then run:
-'builder signing setup --certificate <downloaded>.cer --key ios-signing.key'.`,
+'builder signing p12 --certificate <downloaded>.cer --key ios-signing.key'.`,
 	RunE: runSigningCSR,
+}
+
+var signingP12Cmd = &cobra.Command{
+	Use:   "p12",
+	Short: "Assemble a .p12 from a private key and an Apple certificate",
+	Long: `Combines the private key from 'builder signing csr' with the certificate
+downloaded from the Apple Developer portal into a password-protected .p12 —
+the same file Keychain Access exports on a Mac.
+
+The .p12 works anywhere a Keychain-exported one does: 'builder signing setup',
+Sideloadly, AltStore, or importing it on a Mac.`,
+	RunE: runSigningP12,
 }
 
 func init() {
 	signingCmd.AddCommand(signingSetupCmd)
 	signingCmd.AddCommand(signingCSRCmd)
+	signingCmd.AddCommand(signingP12Cmd)
 
 	signingSetupCmd.Flags().StringP("certificate", "c", "", "Path to certificate file (.p12, or .cer from the Apple Developer portal)")
 	signingSetupCmd.Flags().StringP("profile", "p", "", "Path to .mobileprovision file")
@@ -66,6 +79,11 @@ func init() {
 
 	signingCSRCmd.Flags().String("name", "", "Your name (certificate common name)")
 	signingCSRCmd.Flags().String("email", "", "Email address of your Apple Developer account")
+
+	signingP12Cmd.Flags().StringP("certificate", "c", "", "Path to the .cer downloaded from the Apple Developer portal")
+	signingP12Cmd.Flags().StringP("key", "k", "", "Path to the private key from 'builder signing csr'")
+	signingP12Cmd.Flags().StringP("out", "o", "ios-signing.p12", "Path to write the .p12 to")
+	signingP12Cmd.Flags().String("password", "", "Password to protect the .p12 (prompted if omitted)")
 }
 
 func runSigningCSR(cmd *cobra.Command, args []string) error {
@@ -122,6 +140,69 @@ func runSigningCSR(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  3. Upload %s and download the certificate (.cer)\n", csrPath)
 	fmt.Printf("  4. Run: builder signing setup --certificate <downloaded>.cer --key %s\n", keyPath)
 
+	return nil
+}
+
+func promptPassword(label string) (string, error) {
+	prompt := promptui.Prompt{Label: label, Mask: '*'}
+	password, err := prompt.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to read password: %w", err)
+	}
+	if password == "" {
+		return "", fmt.Errorf("a password is required")
+	}
+	return password, nil
+}
+
+// buildP12From reads a key and certificate from disk and assembles a .p12.
+func buildP12From(keyPath, certPath, password string) ([]byte, error) {
+	keyPEM, err := os.ReadFile(expandPath(keyPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key %s: %w", keyPath, err)
+	}
+	certData, err := os.ReadFile(expandPath(certPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read certificate %s: %w", certPath, err)
+	}
+	return signing.BuildP12(keyPEM, certData, password)
+}
+
+func runSigningP12(cmd *cobra.Command, args []string) error {
+	certPath, _ := cmd.Flags().GetString("certificate")
+	keyPath, _ := cmd.Flags().GetString("key")
+	outPath, _ := cmd.Flags().GetString("out")
+	password, _ := cmd.Flags().GetString("password")
+
+	var err error
+	if certPath == "" {
+		if certPath, err = promptString("Path to certificate (.cer from the Apple Developer portal)", ""); err != nil {
+			return err
+		}
+	}
+	if keyPath == "" {
+		if keyPath, err = promptString("Path to private key", "ios-signing.key"); err != nil {
+			return err
+		}
+	}
+	if certPath == "" || keyPath == "" {
+		return fmt.Errorf("certificate and key are required")
+	}
+	if password == "" {
+		if password, err = promptPassword("Password to protect the .p12"); err != nil {
+			return err
+		}
+	}
+
+	p12, err := buildP12From(keyPath, certPath, password)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(expandPath(outPath), p12, 0600); err != nil {
+		return fmt.Errorf("failed to write .p12: %w", err)
+	}
+
+	fmt.Printf("Created %s (do not commit it)\n", outPath)
 	return nil
 }
 
@@ -209,21 +290,13 @@ func runSigningSetup(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		}
-		keyPath = expandPath(keyPath)
-		keyPEM, err := os.ReadFile(keyPath)
+		keyPEM, err := os.ReadFile(expandPath(keyPath))
 		if err != nil {
 			return fmt.Errorf("failed to read private key %s: %w", keyPath, err)
 		}
-		passwordPrompt := promptui.Prompt{
-			Label: "Password to protect the .p12",
-			Mask:  '*',
-		}
-		password, err = passwordPrompt.Run()
+		password, err = promptPassword("Password to protect the .p12")
 		if err != nil {
-			return fmt.Errorf("failed to read password: %w", err)
-		}
-		if password == "" {
-			return fmt.Errorf("a password is required")
+			return err
 		}
 		certData, err = signing.BuildP12(keyPEM, certData, password)
 		if err != nil {
@@ -237,17 +310,9 @@ func runSigningSetup(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Assembled .p12: %s (do not commit it)\n", p12Path)
 	} else {
-		// Get certificate password (no echo)
-		passwordPrompt := promptui.Prompt{
-			Label: "Certificate password",
-			Mask:  '*',
-		}
-		password, err = passwordPrompt.Run()
+		password, err = promptPassword("Certificate password")
 		if err != nil {
-			return fmt.Errorf("failed to read password: %w", err)
-		}
-		if password == "" {
-			return fmt.Errorf("certificate password is required")
+			return err
 		}
 	}
 

--- a/cmd/builder/signing.go
+++ b/cmd/builder/signing.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -152,14 +151,6 @@ func isPortalCertificate(path string) bool {
 	return false
 }
 
-func randomPassword() (string, error) {
-	buf := make([]byte, 18)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(buf), nil
-}
-
 // expandPath normalizes a path typed at a prompt. The shell never sees these,
 // so a leading ~ is not expanded, and dragging a file into the terminal can
 // wrap it in quotes and escape spaces.
@@ -238,15 +229,28 @@ func runSigningSetup(cmd *cobra.Command, args []string) error {
 			}
 			return fmt.Errorf("failed to read signing key: %w", err)
 		}
-		password, err = randomPassword()
+		passwordPrompt := promptui.Prompt{
+			Label: "Password to protect the .p12",
+			Mask:  '*',
+		}
+		password, err = passwordPrompt.Run()
 		if err != nil {
-			return fmt.Errorf("failed to generate password: %w", err)
+			return fmt.Errorf("failed to read password: %w", err)
+		}
+		if password == "" {
+			return fmt.Errorf("a password is required")
 		}
 		certData, err = signing.BuildP12(keyPEM, certData, password)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Assembled .p12 from certificate and signing key")
+		// Keep the .p12 next to the key: it is the reusable signing identity
+		// (Sideloadly, another machine, re-running setup), not a throwaway.
+		p12Path := filepath.Join(filepath.Dir(keyPath), "signing.p12")
+		if err := os.WriteFile(p12Path, certData, 0600); err != nil {
+			return fmt.Errorf("failed to write .p12: %w", err)
+		}
+		fmt.Printf("Assembled .p12 and saved it to %s\n", p12Path)
 	} else {
 		// Get certificate password (no echo)
 		passwordPrompt := promptui.Prompt{

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/crypto v0.47.0
 	howett.net/plist v1.0.1
+	software.sslmate.com/src/go-pkcs12 v0.7.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -83,3 +83,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
 howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
+software.sslmate.com/src/go-pkcs12 v0.7.3 h1:JBQD3FDqYjTeyDAeZQklj2ar88ykBLtALloPJHyAauU=
+software.sslmate.com/src/go-pkcs12 v0.7.3/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -120,8 +120,8 @@ func storeToken(token string) error {
 	return storeTokenToFile(token)
 }
 
-// getConfigDir returns the path to ~/.config/ios-builder/
-func getConfigDir() (string, error) {
+// ConfigDir returns the path to ~/.config/ios-builder/
+func ConfigDir() (string, error) {
 	var configBase string
 	if runtime.GOOS == "windows" {
 		configBase = os.Getenv("APPDATA")
@@ -147,7 +147,7 @@ func getConfigDir() (string, error) {
 
 // storeTokenToFile saves the token to ~/.config/ios-builder/token with restricted permissions.
 func storeTokenToFile(token string) error {
-	configDir, err := getConfigDir()
+	configDir, err := ConfigDir()
 	if err != nil {
 		return fmt.Errorf("failed to get config directory: %w", err)
 	}
@@ -163,7 +163,7 @@ func storeTokenToFile(token string) error {
 
 // getTokenFromFile reads the token from ~/.config/ios-builder/token.
 func getTokenFromFile() (string, error) {
-	configDir, err := getConfigDir()
+	configDir, err := ConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get config directory: %w", err)
 	}
@@ -184,7 +184,7 @@ func getTokenFromFile() (string, error) {
 
 // deleteTokenFile removes the token file.
 func deleteTokenFile() error {
-	configDir, err := getConfigDir()
+	configDir, err := ConfigDir()
 	if err != nil {
 		return err
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -120,8 +120,8 @@ func storeToken(token string) error {
 	return storeTokenToFile(token)
 }
 
-// ConfigDir returns the path to ~/.config/ios-builder/
-func ConfigDir() (string, error) {
+// getConfigDir returns the path to ~/.config/ios-builder/
+func getConfigDir() (string, error) {
 	var configBase string
 	if runtime.GOOS == "windows" {
 		configBase = os.Getenv("APPDATA")
@@ -147,7 +147,7 @@ func ConfigDir() (string, error) {
 
 // storeTokenToFile saves the token to ~/.config/ios-builder/token with restricted permissions.
 func storeTokenToFile(token string) error {
-	configDir, err := ConfigDir()
+	configDir, err := getConfigDir()
 	if err != nil {
 		return fmt.Errorf("failed to get config directory: %w", err)
 	}
@@ -163,7 +163,7 @@ func storeTokenToFile(token string) error {
 
 // getTokenFromFile reads the token from ~/.config/ios-builder/token.
 func getTokenFromFile() (string, error) {
-	configDir, err := ConfigDir()
+	configDir, err := getConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get config directory: %w", err)
 	}
@@ -184,7 +184,7 @@ func getTokenFromFile() (string, error) {
 
 // deleteTokenFile removes the token file.
 func deleteTokenFile() error {
-	configDir, err := ConfigDir()
+	configDir, err := getConfigDir()
 	if err != nil {
 		return err
 	}

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -1,0 +1,94 @@
+// Package signing creates iOS code-signing material without a Mac: it
+// generates the certificate signing request that Keychain Access would
+// normally produce, and assembles a .p12 from the certificate Apple issues.
+package signing
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
+)
+
+// GenerateKeyAndCSR creates an RSA-2048 private key and a certificate signing
+// request for the Apple Developer portal, both PEM-encoded. Apple requires
+// RSA 2048 for signing certificates; the subject mirrors what Keychain Access
+// puts in its CSRs (email address and common name).
+func GenerateKeyAndCSR(commonName, email string) (keyPEM, csrPEM []byte, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: commonName,
+			ExtraNames: []pkix.AttributeTypeAndValue{
+				// emailAddress (OID 1.2.840.113549.1.9.1), as in Keychain CSRs.
+				// Forced to IA5String: Go would otherwise encode the '@' as
+				// UTF8String, which is not the standard encoding for this field.
+				{
+					Type:  []int{1, 2, 840, 113549, 1, 9, 1},
+					Value: asn1.RawValue{Tag: asn1.TagIA5String, Bytes: []byte(email)},
+				},
+			},
+		},
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create CSR: %w", err)
+	}
+
+	keyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	csrPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrDER,
+	})
+	return keyPEM, csrPEM, nil
+}
+
+// BuildP12 combines a PEM private key (from GenerateKeyAndCSR) with the
+// certificate Apple issued for its CSR (DER .cer as downloaded from the
+// portal, or PEM) into a password-protected PKCS#12 bundle, the same format
+// Keychain Access exports. The legacy encoding is used because that is what
+// macOS `security import` expects.
+func BuildP12(keyPEM, certData []byte, password string) ([]byte, error) {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, fmt.Errorf("invalid private key: not PEM encoded")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	certDER := certData
+	if certBlock, _ := pem.Decode(certData); certBlock != nil {
+		certDER = certBlock.Bytes
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate (expected the .cer file downloaded from the Apple Developer portal): %w", err)
+	}
+
+	certKey, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok || !certKey.Equal(key.Public()) {
+		return nil, fmt.Errorf("certificate does not match the private key: it was issued for a different CSR (was the key regenerated after uploading the CSR?)")
+	}
+
+	p12, err := pkcs12.Legacy.Encode(key, cert, nil, password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create .p12: %w", err)
+	}
+	return p12, nil
+}

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -1,0 +1,131 @@
+package signing
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
+)
+
+func TestGenerateKeyAndCSR(t *testing.T) {
+	keyPEM, csrPEM, err := GenerateKeyAndCSR("Jane Developer", "jane@example.com")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil || keyBlock.Type != "RSA PRIVATE KEY" {
+		t.Fatalf("key is not a PEM RSA PRIVATE KEY block")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("ParsePKCS1PrivateKey: %v", err)
+	}
+	if key.N.BitLen() != 2048 {
+		t.Errorf("key size = %d, want 2048", key.N.BitLen())
+	}
+
+	csrBlock, _ := pem.Decode(csrPEM)
+	if csrBlock == nil || csrBlock.Type != "CERTIFICATE REQUEST" {
+		t.Fatalf("CSR is not a PEM CERTIFICATE REQUEST block")
+	}
+	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificateRequest: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		t.Errorf("CSR signature invalid: %v", err)
+	}
+	if csr.Subject.CommonName != "Jane Developer" {
+		t.Errorf("CommonName = %q, want %q", csr.Subject.CommonName, "Jane Developer")
+	}
+	// emailAddress must be present and IA5String-encoded (tag 0x16), the
+	// encoding Keychain and OpenSSL use; Subject.String() hex-prints it, so
+	// check the raw DER.
+	emailIA5 := append([]byte{0x16, byte(len("jane@example.com"))}, "jane@example.com"...)
+	if !bytes.Contains(csrBlock.Bytes, emailIA5) {
+		t.Errorf("CSR does not contain IA5String-encoded email address")
+	}
+}
+
+// issueCert signs a certificate for pub, standing in for the Apple portal.
+func issueCert(t *testing.T, pub *rsa.PublicKey, signer *rsa.PrivateKey) []byte {
+	t.Helper()
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Apple Development: Jane Developer"},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, pub, signer)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return certDER
+}
+
+func TestBuildP12Roundtrip(t *testing.T) {
+	keyPEM, _, err := GenerateKeyAndCSR("Jane Developer", "jane@example.com")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("ParsePKCS1PrivateKey: %v", err)
+	}
+	certDER := issueCert(t, &key.PublicKey, key)
+
+	p12, err := BuildP12(keyPEM, certDER, "secret")
+	if err != nil {
+		t.Fatalf("BuildP12: %v", err)
+	}
+
+	gotKey, gotCert, err := pkcs12.Decode(p12, "secret")
+	if err != nil {
+		t.Fatalf("pkcs12.Decode: %v", err)
+	}
+	if !gotKey.(*rsa.PrivateKey).Equal(key) {
+		t.Errorf("decoded key does not match original")
+	}
+	if gotCert.Subject.CommonName != "Apple Development: Jane Developer" {
+		t.Errorf("decoded cert CN = %q", gotCert.Subject.CommonName)
+	}
+}
+
+func TestBuildP12AcceptsPEMCertificate(t *testing.T) {
+	keyPEM, _, err := GenerateKeyAndCSR("Jane Developer", "jane@example.com")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	key, _ := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: issueCert(t, &key.PublicKey, key),
+	})
+
+	if _, err := BuildP12(keyPEM, certPEM, "secret"); err != nil {
+		t.Errorf("BuildP12 with PEM certificate: %v", err)
+	}
+}
+
+func TestBuildP12RejectsMismatchedCertificate(t *testing.T) {
+	keyPEM, _, err := GenerateKeyAndCSR("Jane Developer", "jane@example.com")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	certDER := issueCert(t, &otherKey.PublicKey, otherKey)
+
+	if _, err := BuildP12(keyPEM, certDER, "secret"); err == nil {
+		t.Errorf("BuildP12 accepted a certificate for a different key")
+	}
+}

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -89,7 +89,8 @@ func TestBuildP12Roundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pkcs12.Decode: %v", err)
 	}
-	if !gotKey.(*rsa.PrivateKey).Equal(key) {
+	rsaKey, ok := gotKey.(*rsa.PrivateKey)
+	if !ok || !rsaKey.Equal(key) {
 		t.Errorf("decoded key does not match original")
 	}
 	if gotCert.Subject.CommonName != "Apple Development: Jane Developer" {


### PR DESCRIPTION
## Why

Feedback claimed a `.p12` can only be created on a Mac, making `builder signing setup` useless for the tool's main audience. That's a misconception — the only Keychain-specific step is generating the key pair and CSR, and builder can do that itself.

## What

- **`builder signing csr`** — new command that generates an RSA-2048 private key and a Keychain-style CSR (CN + IA5String `emailAddress`, verified against OpenSSL) for the Apple Developer portal. Writes `ios-signing.key` (0600) and `ios-signing.csr` to the current directory — no hidden state, the user decides where the files live — and prints a note not to commit the key plus the portal steps to follow.
- **`builder signing setup --certificate <file>.cer --key ios-signing.key`** — setup now accepts the certificate downloaded from the portal together with the private key as explicit inputs. It assembles `ios-signing.p12` protected by a password the user chooses, saves it to the working directory (it's the reusable signing identity — works with Sideloadly, a Mac, re-runs), and uploads the same three secrets as before. A mismatched certificate (key regenerated after uploading the CSR) is rejected with a clear error. Existing `.p12` files keep working unchanged.
- **README** — step-by-step no-Mac walkthrough: CSR → certificate on the portal → App ID / device UDID / provisioning profile → `signing setup`. Notes the paid-membership requirement, that the key/p12 must not be committed (gitignored files are also excluded from build snapshots), and points free-account users at MobAI re-signing.
- New `internal/signing` package with tests.

## Verification

- `go test ./...` green; new tests cover CSR structure/signature, `.p12` roundtrip, PEM certs, and key/cert mismatch.
- Generated CSR verified with `openssl req -verify`: `subject=CN=Jane Developer, emailAddress=jane@example.com` — identical shape to a Keychain CSR.
- Generated `.p12` imported into a temp keychain with the exact `security import` invocation the workflow uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)