### PR TITLE
Kotlin Multiplatform support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ go install ./cmd/builder
 ./builder ios build         # Trigger build and download IPA to ./dist/
 ./builder dev flutter       # Flutter hot reload with MobAI
 ./builder dev rn            # React Native hot reload with MobAI
+./builder dev kmp           # Kotlin Multiplatform install + launch (no hot reload)
 ./builder dev flutter --skip-install --bundle-id <id>  # Use already installed app
 ./builder dev rn --skip-install --bundle-id <id>       # Use already installed app
 ```
@@ -91,6 +92,14 @@ builder dev rn ──────────► Starts Metro bundler (if not ru
                                 │
                                 ▼
                           Launches app with Metro URL env vars
+
+builder dev kmp ─────────► Connects to MobAI
+                                │
+                                ▼
+                          Installs IPA on device (with optional re-sign)
+                                │
+                                ▼
+                          Launches app and streams output (no hot reload)
 ```
 
 ### Module Layout
@@ -131,7 +140,12 @@ internal/
 - **Flutter Custom Devices**: Auto-configures `~/.config/flutter/custom_devices.json` for `mobai-ios` device
 - **Debug URL Capture**: WebSocket stream captures VM Service URL from app launch
 - **React Native Metro**: Auto-starts Metro bundler, passes Metro URL to app via environment variables
-- **FrameworkHandler Interface**: Common session with pluggable handlers for Flutter/React Native
+- **FrameworkHandler Interface**: Common session with pluggable handlers for Flutter/React Native/KMP
+- **KMP Detection**: The multiplatform Gradle plugin is matched by regex in root and module build
+  files. `cmd/builder/root.go` (`kmpPluginRe`) and both workflow templates must agree: a project the
+  CLI calls KMP but the runner does not gets no JDK, and vice versa.
+- **KMP Has No Hot Reload**: shared Kotlin compiles to a native framework at build time, so
+  `dev kmp` only installs, launches and streams output; code changes need `ios build`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ gh secret set MOBAI_API_KEY
 | React Native | `ios/` | Yes |
 | Expo (ejected) | `ios/` | Yes |
 | Flutter | `ios/` | Yes |
+| Kotlin Multiplatform | `iosApp/` | Yes |
 | Cordova/Ionic | `platforms/ios/` | Yes |
 
 ## Installation
@@ -130,6 +131,7 @@ builder dev flutter           # Flutter hot reload with file watching
 builder dev flutter --no-watch  # Disable automatic file watching
 builder dev flutter --no-attach # Print flutter attach command instead of running it
 builder dev rn                # React Native hot reload (alias: react-native)
+builder dev kmp               # Kotlin Multiplatform install + launch (alias: kotlin)
 builder dev flutter --skip-install --bundle-id <id>  # Use already installed app
 builder dev rn --metro-port 8082  # Use custom Metro port
 
@@ -404,6 +406,56 @@ builder dev rn --metro-port 8082
 - Shake device or press `d` in Metro terminal to open dev menu
 - Enable "Fast Refresh" in dev menu
 - Try reloading with `r` in Metro terminal
+
+## Kotlin Multiplatform Development
+
+KMP iOS apps build and run on a device like any other project, with one
+difference: **there is no hot reload.** Shared Kotlin is compiled into a native
+framework at build time, so there is no runtime to swap code into — every code
+change needs a rebuild.
+
+### Setup
+
+1. Download and install [MobAI](https://mobai.run/download), then connect your iOS device
+2. Build your app:
+   ```bash
+   builder ios build
+   ```
+3. Install and launch it on the device:
+   ```bash
+   builder dev kmp
+   ```
+
+`builder init` detects Kotlin Multiplatform projects by looking for the
+multiplatform Gradle plugin in the root and module build files, and asks which
+JDK the CI build should use (default 17):
+
+```json
+{
+  "kmp": { "jdkVersion": "17" }
+}
+```
+
+On CI, the iOS app is built with `xcodebuild`, whose run script phase (or
+CocoaPods) invokes Gradle to compile the shared framework — which is why the
+JDK version matters. Gradle output is cached between builds.
+
+### When to Rebuild
+
+Every change to Kotlin or Swift code needs `builder ios build` followed by
+`builder dev kmp` again. Use `--skip-install --bundle-id <id>` to relaunch an
+app that is already installed.
+
+### Troubleshooting
+
+**Build fails with "Unsupported class file major version" or a Gradle JDK error**
+- The project needs a different JDK than the default: set `kmp.jdkVersion` in `builder.json` to match what the project uses locally
+
+**Build fails with "SDK does not contain 'libarclite'"**
+- An old Kotlin/Native version against a newer Xcode; upgrade the Kotlin plugin in Gradle
+
+**App launches then immediately exits**
+- Launch with `builder dev kmp --logs` to see the device output
 
 ## Build Limits
 

--- a/cmd/builder/kmp.go
+++ b/cmd/builder/kmp.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/MobAI-App/ios-builder/internal/config"
+	"github.com/MobAI-App/ios-builder/internal/dev"
+	"github.com/MobAI-App/ios-builder/internal/mobai"
+	"github.com/spf13/cobra"
+)
+
+var devKMPCmd = &cobra.Command{
+	Use:     "kmp",
+	Aliases: []string{"kotlin"},
+	Short:   "Install and launch a Kotlin Multiplatform app on device",
+	Long: `Installs and launches a Kotlin Multiplatform iOS app on a device using MobAI.
+
+Kotlin Multiplatform has no hot reload on iOS: the shared Kotlin code is compiled
+to a native framework at build time. For code changes, rebuild with
+'builder ios build' and re-run this command.
+
+Prerequisites:
+- MobAI running with an iOS device connected
+- IPA built with 'builder ios build'`,
+	RunE: runDevKMP,
+}
+
+func init() {
+	devCmd.AddCommand(devKMPCmd)
+	devKMPCmd.Flags().StringP("device", "d", "", "Device ID (default: first available)")
+	devKMPCmd.Flags().String("mobai-url", mobai.DefaultBaseURL, "MobAI API URL")
+	devKMPCmd.Flags().String("ipa", "", "Path to IPA (default: auto-detect from dist/)")
+	devKMPCmd.Flags().Bool("skip-install", false, "Skip app installation (app must already be installed)")
+	devKMPCmd.Flags().String("bundle-id", "", "Bundle ID (required with --skip-install)")
+	devKMPCmd.Flags().Bool("logs", false, "Show app logs")
+}
+
+func runDevKMP(cmd *cobra.Command, args []string) error {
+	deviceID, _ := cmd.Flags().GetString("device")
+	mobaiURL, _ := cmd.Flags().GetString("mobai-url")
+	ipaPath, _ := cmd.Flags().GetString("ipa")
+	skipInstall, _ := cmd.Flags().GetBool("skip-install")
+	bundleID, _ := cmd.Flags().GetString("bundle-id")
+	showLogs, _ := cmd.Flags().GetBool("logs")
+
+	if cfg, err := config.NewManager().Load(); err == nil {
+		if !cmd.Flags().Changed("mobai-url") && cfg.MobAI.URL != "" {
+			mobaiURL = cfg.MobAI.URL
+		}
+		if !cmd.Flags().Changed("device") && cfg.MobAI.DeviceID != "" {
+			deviceID = cfg.MobAI.DeviceID
+		}
+	}
+
+	if skipInstall {
+		if bundleID == "" {
+			return fmt.Errorf("--bundle-id is required when using --skip-install")
+		}
+	} else {
+		if ipaPath == "" {
+			var err error
+			ipaPath, err = dev.FindIPA("dist")
+			if err != nil {
+				return err
+			}
+		}
+
+		if _, err := os.Stat(ipaPath); os.IsNotExist(err) {
+			return fmt.Errorf("IPA not found: %s", ipaPath)
+		}
+
+		fmt.Printf("Found IPA: %s\n", ipaPath)
+		fmt.Println()
+	}
+
+	handler := dev.NewKMPHandler(showLogs)
+	session := dev.NewSession(mobaiURL, deviceID, ipaPath, handler)
+	session.SetSkipInstall(skipInstall, bundleID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+
+	go func() {
+		<-sigChan
+		fmt.Println("\nShutting down...")
+		cancel()
+		session.Stop()
+	}()
+
+	err := session.Start(ctx)
+	session.Stop()
+
+	if _, ok := err.(*dev.RuntimeError); ok {
+		fmt.Println()
+		fmt.Println("Tip: If connection failed, try:")
+		fmt.Println("  1. Reconnect the device (unplug/replug)")
+		fmt.Println("  2. Restart MobAI")
+		fmt.Println("  3. Run 'builder mobai ping' to verify connection")
+	}
+
+	return err
+}

--- a/cmd/builder/kmp_test.go
+++ b/cmd/builder/kmp_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// chdir moves into a fresh temp directory for the duration of the test, since
+// isKMPProject scans the working directory.
+func chdir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	return dir
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestIsKMPProject(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  bool
+	}{
+		{
+			name:  "kotlin dsl in root build file",
+			files: map[string]string{"build.gradle.kts": "plugins {\n  kotlin(\"multiplatform\")\n}\n"},
+			want:  true,
+		},
+		{
+			name:  "plugin in a module build file",
+			files: map[string]string{"shared/build.gradle.kts": "plugins {\n  kotlin(\"multiplatform\")\n}\n"},
+			want:  true,
+		},
+		{
+			name:  "groovy plugin id",
+			files: map[string]string{"shared/build.gradle": "apply plugin: 'org.jetbrains.kotlin.multiplatform'\n"},
+			want:  true,
+		},
+		{
+			name:  "plugins block with id()",
+			files: map[string]string{"build.gradle.kts": "plugins {\n  id(\"org.jetbrains.kotlin.multiplatform\") version \"2.0.0\"\n}\n"},
+			want:  true,
+		},
+		{
+			name:  "android-only gradle project",
+			files: map[string]string{"build.gradle.kts": "plugins {\n  id(\"com.android.application\")\n  kotlin(\"android\")\n}\n"},
+			want:  false,
+		},
+		{
+			// The bare word appears in prose and dependency names far more often
+			// than the plugin itself; matching it would misconfigure the build.
+			name:  "word multiplatform in a comment",
+			files: map[string]string{"build.gradle.kts": "// we may go multiplatform one day\nplugins {\n  kotlin(\"jvm\")\n}\n"},
+			want:  false,
+		},
+		{
+			name:  "no gradle files at all",
+			files: map[string]string{"package.json": `{"name":"app"}`},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := chdir(t)
+			for name, content := range tt.files {
+				writeFile(t, filepath.Join(dir, name), content)
+			}
+			if got := isKMPProject(); got != tt.want {
+				t.Errorf("isKMPProject() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/builder/kmp_test.go
+++ b/cmd/builder/kmp_test.go
@@ -59,6 +59,26 @@ func TestIsKMPProject(t *testing.T) {
 			want:  true,
 		},
 		{
+			// How most current KMP projects declare it: the id lives in the
+			// version catalog and build files only reference the alias.
+			name: "version catalog alias",
+			files: map[string]string{
+				"gradle/libs.versions.toml": "[plugins]\nkotlin-multiplatform = { id = \"org.jetbrains.kotlin.multiplatform\", version.ref = \"kotlin\" }\n",
+				"shared/build.gradle.kts":   "plugins {\n  alias(libs.plugins.kotlin.multiplatform)\n}\n",
+			},
+			want: true,
+		},
+		{
+			// A catalog can mention unrelated libraries whose names contain
+			// "multiplatform" (multiplatform-settings and friends).
+			name: "catalog with only multiplatform-named libraries",
+			files: map[string]string{
+				"gradle/libs.versions.toml": "[versions]\nmultiplatformSettings = \"1.3.0\"\n[libraries]\nsettings = { module = \"com.russhwolf:multiplatform-settings\" }\n",
+				"build.gradle.kts":          "plugins {\n  kotlin(\"jvm\")\n}\n",
+			},
+			want: false,
+		},
+		{
 			name:  "android-only gradle project",
 			files: map[string]string{"build.gradle.kts": "plugins {\n  id(\"com.android.application\")\n  kotlin(\"android\")\n}\n"},
 			want:  false,

--- a/cmd/builder/root.go
+++ b/cmd/builder/root.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -120,6 +121,40 @@ func isExpoProject() bool {
 	return strings.Contains(string(data), `"expo"`)
 }
 
+// isKMPProject reports whether the current directory looks like a Kotlin
+// Multiplatform project. The multiplatform plugin usually lives in a module's
+// build file (e.g. shared/build.gradle.kts) rather than the root, so we scan
+// root and immediate subdirectory Gradle files.
+func isKMPProject() bool {
+	hasMultiplatform := func(path string) bool {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(string(data), "multiplatform")
+	}
+
+	if slices.ContainsFunc([]string{"settings.gradle.kts", "settings.gradle", "build.gradle.kts", "build.gradle"}, hasMultiplatform) {
+		return true
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		for _, name := range []string{"build.gradle.kts", "build.gradle"} {
+			if hasMultiplatform(filepath.Join(e.Name(), name)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func getLocalFlutterVersion() string {
 	cmd := exec.Command("flutter", "--version", "--machine")
 	output, err := cmd.Output()
@@ -142,6 +177,7 @@ func detectIOSPath() (string, string) {
 		framework string
 	}{
 		{"ios", "React Native/Expo"},
+		{"iosApp", "Kotlin Multiplatform"},
 		{"platforms/ios", "Cordova/Ionic"},
 	}
 
@@ -273,6 +309,18 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Detect Kotlin Multiplatform and prompt for JDK version
+	var jdkVersion string
+	if isKMPProject() {
+		fmt.Println()
+		fmt.Println("Detected Kotlin Multiplatform project")
+		fmt.Println("Note: KMP has no hot reload on iOS - rebuild for code changes.")
+		jdkVersion, err = promptString("JDK version for Gradle builds", "17")
+		if err != nil {
+			return err
+		}
+	}
+
 	fmt.Println()
 	fmt.Printf("Project:    %s\n", projectName)
 	fmt.Printf("Repository: %s/%s\n", githubOwner, repoName)
@@ -281,6 +329,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	if flutterVersion != "" {
 		fmt.Printf("Flutter:    %s\n", flutterVersion)
+	}
+	if jdkVersion != "" {
+		fmt.Printf("JDK:        %s\n", jdkVersion)
 	}
 	fmt.Println()
 
@@ -331,6 +382,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 		},
 		ReactNative: config.ReactNativeConfig{
 			Expo: isExpoProject(),
+		},
+		KMP: config.KMPConfig{
+			JDKVersion: jdkVersion,
 		},
 	}
 

--- a/cmd/builder/root.go
+++ b/cmd/builder/root.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"syscall"
@@ -121,6 +122,12 @@ func isExpoProject() bool {
 	return strings.Contains(string(data), `"expo"`)
 }
 
+// kmpPluginRe matches a declaration of the Kotlin Multiplatform Gradle plugin,
+// in the Kotlin DSL (`kotlin("multiplatform")`) or Groovy/plugin-id form. It
+// must stay in step with the detection in the workflow template: a project the
+// CLI calls KMP but the runner does not gets no JDK, and vice versa.
+var kmpPluginRe = regexp.MustCompile(`kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\(["']org\.jetbrains\.kotlin\.multiplatform["']\)`)
+
 // isKMPProject reports whether the current directory looks like a Kotlin
 // Multiplatform project. The multiplatform plugin usually lives in a module's
 // build file (e.g. shared/build.gradle.kts) rather than the root, so we scan
@@ -131,7 +138,7 @@ func isKMPProject() bool {
 		if err != nil {
 			return false
 		}
-		return strings.Contains(string(data), "multiplatform")
+		return kmpPluginRe.Match(data)
 	}
 
 	if slices.ContainsFunc([]string{"settings.gradle.kts", "settings.gradle", "build.gradle.kts", "build.gradle"}, hasMultiplatform) {

--- a/cmd/builder/root.go
+++ b/cmd/builder/root.go
@@ -132,6 +132,11 @@ var kmpPluginRe = regexp.MustCompile(`kotlin\("multiplatform"\)|org\.jetbrains\.
 // Multiplatform project. The multiplatform plugin usually lives in a module's
 // build file (e.g. shared/build.gradle.kts) rather than the root, so we scan
 // root and immediate subdirectory Gradle files.
+//
+// Projects using a version catalog declare the plugin id once in
+// gradle/libs.versions.toml and reference it as `alias(libs.plugins.…)` in the
+// build files, so the catalog is scanned too — that is how most current KMP
+// projects (KaMPKit, PeopleInSpace) are set up.
 func isKMPProject() bool {
 	hasMultiplatform := func(path string) bool {
 		data, err := os.ReadFile(path)
@@ -141,7 +146,12 @@ func isKMPProject() bool {
 		return kmpPluginRe.Match(data)
 	}
 
-	if slices.ContainsFunc([]string{"settings.gradle.kts", "settings.gradle", "build.gradle.kts", "build.gradle"}, hasMultiplatform) {
+	roots := []string{
+		"settings.gradle.kts", "settings.gradle",
+		"build.gradle.kts", "build.gradle",
+		filepath.Join("gradle", "libs.versions.toml"),
+	}
+	if slices.ContainsFunc(roots, hasMultiplatform) {
 		return true
 	}
 

--- a/internal/build/coordinator.go
+++ b/internal/build/coordinator.go
@@ -128,6 +128,10 @@ func (c *Coordinator) Build(ctx context.Context, opts BuildOptions) (*BuildResul
 	if c.config.Flutter.Version != "" {
 		inputs["flutter_version"] = c.config.Flutter.Version
 	}
+	// Pass JDK version for Kotlin Multiplatform Gradle builds
+	if c.config.KMP.JDKVersion != "" {
+		inputs["jdk_version"] = c.config.KMP.JDKVersion
+	}
 	if err := c.github.TriggerWorkflow(ctx, c.config.GitHub.Owner, c.config.GitHub.Repo, WorkflowFile, inputs); err != nil {
 		c.progress.Error(PhaseTriggering, err)
 		return nil, fmt.Errorf("failed to trigger workflow: %w", err)

--- a/internal/build/share.go
+++ b/internal/build/share.go
@@ -82,6 +82,9 @@ func (c *Coordinator) Share(ctx context.Context, opts ShareOptions) (*ShareResul
 	if c.config.Flutter.Version != "" {
 		inputs["flutter_version"] = c.config.Flutter.Version
 	}
+	if c.config.KMP.JDKVersion != "" {
+		inputs["jdk_version"] = c.config.KMP.JDKVersion
+	}
 	if err := c.github.TriggerWorkflow(ctx, c.config.GitHub.Owner, c.config.GitHub.Repo, ShareWorkflowFile, inputs); err != nil {
 		c.progress.Error(PhaseTriggering, err)
 		return nil, fmt.Errorf("failed to trigger workflow: %w", err)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -8,6 +8,7 @@ type Config struct {
 	IOS         IOSConfig         `json:"ios,omitempty"`
 	Flutter     FlutterConfig     `json:"flutter,omitempty"`
 	ReactNative ReactNativeConfig `json:"reactNative,omitempty"`
+	KMP         KMPConfig         `json:"kmp,omitempty"`
 	MobAI       MobAIConfig       `json:"mobai,omitempty"`
 }
 
@@ -29,6 +30,14 @@ type WatchConfig struct {
 type ReactNativeConfig struct {
 	MetroPort int  `json:"metroPort,omitempty"` // Metro bundler port (default: 8081)
 	Expo      bool `json:"expo,omitempty"`      // Whether this is an Expo project
+}
+
+// KMPConfig holds Kotlin Multiplatform-specific settings.
+// The iOS app is built with xcodebuild, which invokes Gradle (via the Xcode
+// "Run Script" build phase, or CocoaPods) to compile the shared Kotlin
+// framework. The CI build therefore needs a JDK available for Gradle.
+type KMPConfig struct {
+	JDKVersion string `json:"jdkVersion,omitempty"` // JDK version for Gradle builds (default: 17)
 }
 
 // IOSConfig holds iOS build settings

--- a/internal/dev/kmp.go
+++ b/internal/dev/kmp.go
@@ -1,0 +1,67 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MobAI-App/ios-builder/internal/mobai"
+)
+
+// KMPHandler implements FrameworkHandler for Kotlin Multiplatform projects.
+//
+// Kotlin Multiplatform has no hot reload on iOS: the shared Kotlin code is
+// compiled to a native framework at build time, so there is no runtime to swap
+// code into. This handler therefore only installs and launches the app; for
+// code changes the IPA must be rebuilt with 'builder ios build'.
+type KMPHandler struct {
+	showLogs bool
+}
+
+// NewKMPHandler creates a new Kotlin Multiplatform handler.
+func NewKMPHandler(showLogs bool) *KMPHandler {
+	return &KMPHandler{showLogs: showLogs}
+}
+
+// Setup is a no-op for Kotlin Multiplatform.
+func (h *KMPHandler) Setup(ctx context.Context) error { return nil }
+
+// DebugConfig returns nil; Kotlin Multiplatform needs no special launch config.
+func (h *KMPHandler) DebugConfig() *mobai.DebugConfig { return nil }
+
+// Attach keeps the app running and streams output. There is no hot reload.
+func (h *KMPHandler) Attach(ctx context.Context, deviceID string, debugOutput <-chan mobai.DebugOutput) error {
+	fmt.Println()
+	fmt.Println("App launched on device.")
+	fmt.Println("Kotlin Multiplatform has no hot reload on iOS.")
+	fmt.Println("For code changes, rebuild with 'builder ios build' and re-run this command.")
+	fmt.Println("  - Press Ctrl+C to stop")
+	fmt.Println()
+
+	for output := range debugOutput {
+		switch output.Type {
+		case "exit":
+			fmt.Println("App exited")
+			return nil
+		case "error":
+			if strings.Contains(output.Message, "launch failed") {
+				fmt.Println()
+				fmt.Println("Launch failed: developer not trusted.")
+				fmt.Println()
+				fmt.Println("On device go to: Settings > General > VPN & Device Management")
+				fmt.Println("Then tap your developer certificate and trust it.")
+				return fmt.Errorf("launch failed: developer not trusted")
+			}
+			fmt.Printf("App error: %s\n", output.Message)
+		case "stdout", "stderr":
+			if h.showLogs && output.Data != "" {
+				fmt.Print(output.Data)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Stop is a no-op for Kotlin Multiplatform.
+func (h *KMPHandler) Stop() {}

--- a/internal/workflow/templates/ios-build.yml
+++ b/internal/workflow/templates/ios-build.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ''
+      jdk_version:
+        description: 'JDK version for Kotlin Multiplatform Gradle builds (e.g., 17).'
+        required: false
+        type: string
+        default: '17'
 
 jobs:
   build:
@@ -83,6 +88,8 @@ jobs:
             echo "type=expo" >> $GITHUB_OUTPUT
           elif [ -f "package.json" ] && grep -q '"react-native"' package.json; then
             echo "type=reactnative" >> $GITHUB_OUTPUT
+          elif grep -rqlE 'kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\("org.jetbrains.kotlin.multiplatform"\)' --include='*.gradle.kts' --include='*.gradle' . 2>/dev/null; then
+            echo "type=kmp" >> $GITHUB_OUTPUT
           else
             echo "type=native" >> $GITHUB_OUTPUT
           fi
@@ -145,6 +152,17 @@ jobs:
       - name: Install npm dependencies
         if: (steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo') && steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm install
+
+      - name: Setup JDK
+        if: steps.detect.outputs.type == 'kmp'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.jdk_version || '17' }}
+
+      - name: Setup Gradle
+        if: steps.detect.outputs.type == 'kmp'
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Restore Pods cache
         uses: actions/cache@v4
@@ -299,9 +317,18 @@ jobs:
               echo "Running: $ARCHIVE_CMD"
               eval $ARCHIVE_CMD
             fi
-          elif [ "$PROJECT_TYPE" = "reactnative" ] || [ "$PROJECT_TYPE" = "expo" ]; then
-            # Use xcodebuild directly for React Native/Expo
-            echo "Building React Native iOS ($CONFIGURATION)..."
+          elif [ "$PROJECT_TYPE" = "reactnative" ] || [ "$PROJECT_TYPE" = "expo" ] || [ "$PROJECT_TYPE" = "kmp" ]; then
+            # Use xcodebuild directly for React Native/Expo and Kotlin Multiplatform.
+            # For KMP, the Xcode build phase (or CocoaPods) invokes Gradle to
+            # compile the shared Kotlin framework, so the JDK must be on PATH.
+            if [ "$PROJECT_TYPE" = "kmp" ]; then
+              echo "Building Kotlin Multiplatform iOS ($CONFIGURATION)..."
+              if [ -f "${GITHUB_WORKSPACE}/gradlew" ]; then
+                chmod +x "${GITHUB_WORKSPACE}/gradlew"
+              fi
+            else
+              echo "Building React Native iOS ($CONFIGURATION)..."
+            fi
             BUILD_CMD="xcodebuild"
             if [ -n "$WORKSPACE" ]; then
               BUILD_CMD="$BUILD_CMD -workspace $WORKSPACE"
@@ -309,11 +336,14 @@ jobs:
               BUILD_CMD="$BUILD_CMD -project $PROJECT"
             fi
 
-            # Auto-detect scheme from workspace name (e.g., MyApp.xcworkspace -> MyApp)
-            if [ -n "$WORKSPACE" ]; then
-              SCHEME=$(basename "$WORKSPACE" .xcworkspace)
-            elif [ -n "$PROJECT" ]; then
-              SCHEME=$(basename "$PROJECT" .xcodeproj)
+            # Auto-detect scheme from workspace/project name (e.g., MyApp.xcworkspace -> MyApp)
+            # unless an explicit scheme was provided.
+            if [ -z "$SCHEME" ]; then
+              if [ -n "$WORKSPACE" ]; then
+                SCHEME=$(basename "$WORKSPACE" .xcworkspace)
+              elif [ -n "$PROJECT" ]; then
+                SCHEME=$(basename "$PROJECT" .xcodeproj)
+              fi
             fi
 
             BUILD_CMD="$BUILD_CMD -scheme '$SCHEME'"

--- a/internal/workflow/templates/ios-build.yml
+++ b/internal/workflow/templates/ios-build.yml
@@ -88,7 +88,7 @@ jobs:
             echo "type=expo" >> $GITHUB_OUTPUT
           elif [ -f "package.json" ] && grep -q '"react-native"' package.json; then
             echo "type=reactnative" >> $GITHUB_OUTPUT
-          elif grep -rqlE 'kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\("org.jetbrains.kotlin.multiplatform"\)' --include='*.gradle.kts' --include='*.gradle' . 2>/dev/null; then
+          elif grep -rqlE 'kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\("org.jetbrains.kotlin.multiplatform"\)' --include='*.gradle.kts' --include='*.gradle' --include='libs.versions.toml' . 2>/dev/null; then
             echo "type=kmp" >> $GITHUB_OUTPUT
           else
             echo "type=native" >> $GITHUB_OUTPUT

--- a/internal/workflow/templates/ios-share.yml
+++ b/internal/workflow/templates/ios-share.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ''
+      jdk_version:
+        description: 'JDK version for Kotlin Multiplatform Gradle builds (e.g., 17).'
+        required: false
+        type: string
+        default: '17'
 
 jobs:
   simulator:
@@ -94,6 +99,8 @@ jobs:
             echo "type=expo" >> $GITHUB_OUTPUT
           elif [ -f "package.json" ] && grep -q '"react-native"' package.json; then
             echo "type=reactnative" >> $GITHUB_OUTPUT
+          elif grep -rqlE 'kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\("org.jetbrains.kotlin.multiplatform"\)' --include='*.gradle.kts' --include='*.gradle' . 2>/dev/null; then
+            echo "type=kmp" >> $GITHUB_OUTPUT
           else
             echo "type=native" >> $GITHUB_OUTPUT
           fi
@@ -144,6 +151,19 @@ jobs:
       - name: Install npm dependencies
         if: steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo'
         run: npm install
+
+      # KMP builds through xcodebuild like a native project, but its Xcode run
+      # script phase shells out to Gradle, which needs a JDK on PATH.
+      - name: Setup JDK
+        if: steps.detect.outputs.type == 'kmp'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.jdk_version || '17' }}
+
+      - name: Setup Gradle
+        if: steps.detect.outputs.type == 'kmp'
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build for the simulator
         id: build

--- a/internal/workflow/templates/ios-share.yml
+++ b/internal/workflow/templates/ios-share.yml
@@ -99,7 +99,7 @@ jobs:
             echo "type=expo" >> $GITHUB_OUTPUT
           elif [ -f "package.json" ] && grep -q '"react-native"' package.json; then
             echo "type=reactnative" >> $GITHUB_OUTPUT
-          elif grep -rqlE 'kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\("org.jetbrains.kotlin.multiplatform"\)' --include='*.gradle.kts' --include='*.gradle' . 2>/dev/null; then
+          elif grep -rqlE 'kotlin\("multiplatform"\)|org\.jetbrains\.kotlin\.multiplatform|id\("org.jetbrains.kotlin.multiplatform"\)' --include='*.gradle.kts' --include='*.gradle' --include='libs.versions.toml' . 2>/dev/null; then
             echo "type=kmp" >> $GITHUB_OUTPUT
           else
             echo "type=native" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Builds and runs Kotlin Multiplatform iOS apps, alongside the existing Flutter / React Native / native support.

- **`builder dev kmp`** (alias `kotlin`) — installs and launches a KMP app on a real device through MobAI, streaming output with `--logs`. Deliberately **no hot reload**: shared Kotlin compiles to a native framework at build time, so there is no runtime to swap code into. The command says so rather than pretending otherwise, and points at `builder ios build` for code changes.
- **CI builds** — both workflow templates detect KMP from the multiplatform Gradle plugin and set up a Temurin JDK plus the Gradle cache. KMP builds through `xcodebuild`, whose run script phase (or CocoaPods) shells out to Gradle for the shared framework — hence the JDK.
- **`builder init`** — detects KMP projects, recognises the `iosApp/` convention, and prompts for the JDK version, stored as `kmp.jdkVersion` in `builder.json` (default 17).

## Rebase and follow-up fixes

The original commit is from late June and predated `builder ios share`, the signing work, and `builder update`. It is rebased onto current main (the one conflict, in the `ios-build.yml` build step, resolved to keep both main's Flutter signing archive block and the KMP branch), plus three fixes:

- **`ios share` did not know about KMP.** Its workflow had no JDK or Gradle setup, so sharing a simulator for a KMP project would have failed in the Gradle build phase. It now detects KMP and sets both up, and `Share` passes `jdk_version` the way `Build` does.
- **Detection was too loose and disagreed with CI.** `isKMPProject` matched the bare word `multiplatform`, so a comment or a dependency name was enough to classify a project as KMP — while the workflow's stricter regex would not, leaving the build with no JDK. Both now match an actual plugin declaration (Kotlin DSL, Groovy, and `id(...)` forms), verified to agree on the same fixtures.
- **No documentation existed.** README gains a Kotlin Multiplatform section (setup, the JDK setting, when to rebuild, troubleshooting) and the framework/commands tables; CLAUDE.md gains the flow diagram and notes that the CLI and workflow detection must stay in step.

## Verification

- `go build`, `go vet`, `go test ./...` all green; both workflow templates parse as YAML.
- New `TestIsKMPProject` covers the Kotlin DSL, Groovy and `id()` plugin forms plus the false-positive cases (a comment mentioning "multiplatform", an Android-only Gradle project, no Gradle files) — the comment case fails on the old substring check.
- The workflow's shell `grep` was run against the same five fixtures and matches the Go regex on every one.

Not covered: no end-to-end run against a real KMP repo yet — the CI path is verified by inspection and YAML validity only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)