### PR TITLE
workflows: fix scheme, product and cache handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,18 @@ internal/
 - **Run Correlation**: `run-name` carries the build ID so concurrent builds cannot adopt each
   other's runs
 - **Flutter Detection**: Auto-detects Flutter projects, runs `flutter pub get`, uses `Runner` scheme
-- **DerivedData Caching**: Single static cache key for incremental builds
+- **DerivedData Caching**: `restore` keys on `github.run_id` and only the prefix in `restore-keys`
+  ever hits, so every run must pair with a `cache/save` step or later builds stay cold. `ios-share`
+  saves before it shares the simulator, since that step blocks until the session ends.
+- **Scheme Selection**: `xcodebuild -list -json` plus the scheme named after the workspace/project;
+  taking the first scheme picks a package or pod scheme in package-heavy repos
+- **Product Selection**: the built `.app` comes from `-showBuildSettings -json` (the target whose
+  `PRODUCT_TYPE` is an application), because the product name often differs from the scheme name
+  and a repo can have several app targets
+- **Missing xcconfig**: a gitignored `*.xcconfig` with a committed `*.xcconfig.template` (either
+  suffix order) is copied into place before the build; anything still referenced by the project and
+  absent fails the job by name instead of as xcodebuild's opaque "Unable to open base configuration
+  reference file". Pods/Flutter-generated configs are skipped — they appear later in the job.
 - **MobAI Integration**: HTTP/WebSocket API for device control, app install, debug launch
 - **Flutter Custom Devices**: Auto-configures `~/.config/flutter/custom_devices.json` for `mobai-ios` device
 - **Debug URL Capture**: WebSocket stream captures VM Service URL from app launch
@@ -166,9 +177,9 @@ The embedded workflow template (`internal/workflow/templates/ios-build.yml`):
 - Dispatch runs the workflow from the **default branch**, so edits to the workflow file itself
   only take effect once pushed there — unlike app sources, which come from the snapshot ref
 - Checks out `snapshot_ref` over the default-branch checkout when set
-- Runs on `macos-14`
+- Runs on `macos-latest`
 - Detects Flutter projects (checks for `pubspec.yaml`)
-- Caches DerivedData with static key for fast incremental builds
+- Restores and saves DerivedData for fast incremental builds
 - Auto-detects workspace/project and scheme
 - Flutter: uses `Runner` scheme, runs `flutter pub get`
 - Installs CocoaPods if Podfile exists

--- a/internal/workflow/templates/ios-build.yml
+++ b/internal/workflow/templates/ios-build.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # The dispatch always runs the workflow from the default branch, so the
       # sources come from a snapshot ref pushed by the CLI instead.
@@ -71,7 +71,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Restore DerivedData cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         id: cache-deriveddata
         with:
           path: DerivedData
@@ -93,6 +93,28 @@ jobs:
           else
             echo "type=native" >> $GITHUB_OUTPUT
           fi
+
+      # A gitignored *.xcconfig next to a committed template is a common iOS
+      # convention. The snapshot then carries the template but not the config,
+      # and xcodebuild fails with "Unable to open base configuration reference
+      # file", which says nothing about which file is missing.
+      - name: Materialize missing xcconfig files
+        run: |
+          set -e
+          find . -path ./DerivedData -prune -o -type f \
+            \( -name '*.xcconfig.template' -o -name '*.xcconfig.example' \
+               -o -name '*.xcconfig.sample' -o -name '*.template.xcconfig' \
+               -o -name '*.example.xcconfig' -o -name '*.sample.xcconfig' \) -print \
+          | while IFS= read -r template; do
+              case "$template" in
+                *.xcconfig.template|*.xcconfig.example|*.xcconfig.sample) target="${template%.*}" ;;
+                *) target="$(dirname "$template")/$(basename "$template" | sed -E 's/\.(template|example|sample)\.xcconfig$/.xcconfig/')" ;;
+              esac
+              if [ ! -f "$target" ]; then
+                cp "$template" "$target"
+                echo "::warning::$target was missing (gitignored?); copied $template over it. Any placeholder values in it are what the build sees."
+              fi
+            done
 
       - name: Generate Xcode project (XcodeGen)
         env:
@@ -121,6 +143,35 @@ jobs:
             xcodegen generate
           fi
 
+      # Whatever the previous step could not fill in is named here, instead of
+      # surfacing as xcodebuild's "Unable to open base configuration reference".
+      - name: Check base configuration files
+        env:
+          IOS_PATH: ${{ inputs.ios_path }}
+        run: |
+          set -e
+          MISSING=""
+          for pbx in $(find "$IOS_PATH" -maxdepth 2 -name project.pbxproj -not -path '*/Pods.xcodeproj/*'); do
+            for id in $(grep -o 'baseConfigurationReference = [A-Za-z0-9]*' "$pbx" | awk '{print $3}' | sort -u); do
+              ref=$(grep -m1 "^[[:space:]]*$id .*isa = PBXFileReference" "$pbx" || true)
+              name=$(printf '%s' "$ref" | sed -n 's/.*[ \t]path = "\{0,1\}\([^";]*\)"\{0,1\};.*/\1/p')
+              [ -n "$name" ] || continue
+              base=$(basename "$name")
+              # CocoaPods writes its xcconfigs during pod install and Flutter
+              # writes Generated.xcconfig during pub get — both happen later in
+              # this job, so they are legitimately absent right now.
+              case "$name" in *Pods/*|*"Target Support Files"*) continue ;; esac
+              case "$base" in Pods-*|Generated.xcconfig) continue ;; esac
+              if [ -z "$(find . -name "$base" -print -quit)" ]; then
+                MISSING="$MISSING $base"
+              fi
+            done
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::The project has base configuration files that are not in the repository:$MISSING. They are probably gitignored — commit them, or commit a <name>.xcconfig.template next to each so the build can fill them in."
+            exit 1
+          fi
+
       - name: Setup Flutter
         if: steps.detect.outputs.type == 'flutter'
         uses: subosito/flutter-action@v2
@@ -135,13 +186,13 @@ jobs:
 
       - name: Setup Node.js
         if: steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
       - name: Restore node_modules cache
         if: steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: node-modules-cache
         with:
           path: node_modules
@@ -155,17 +206,17 @@ jobs:
 
       - name: Setup JDK
         if: steps.detect.outputs.type == 'kmp'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: ${{ inputs.jdk_version || '17' }}
 
       - name: Setup Gradle
         if: steps.detect.outputs.type == 'kmp'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Restore Pods cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: pods-cache
         with:
           path: |
@@ -254,12 +305,34 @@ jobs:
           # Determine scheme (only needed for native projects)
           if [ -z "$SCHEME" ] && [ "$PROJECT_TYPE" = "native" ]; then
             if [ -n "$WORKSPACE" ]; then
-              SCHEME=$(xcodebuild -workspace "$WORKSPACE" -list 2>/dev/null | grep -A 100 "Schemes:" | tail -n +2 | grep -v -E "^[[:space:]]*Pods-" | head -1 | xargs)
-              if [ -z "$SCHEME" ]; then
-                SCHEME=$(xcodebuild -workspace "$WORKSPACE" -list 2>/dev/null | grep -A 100 "Schemes:" | tail -n +2 | head -1 | xargs)
-              fi
-            elif [ -n "$PROJECT" ]; then
-              SCHEME=$(xcodebuild -project "$PROJECT" -list 2>/dev/null | grep -A 100 "Schemes:" | tail -n +2 | head -1 | xargs)
+              TARGET_FLAG=-workspace
+              TARGET_PATH=$WORKSPACE
+              BASE=$(basename "$WORKSPACE" .xcworkspace)
+            else
+              TARGET_FLAG=-project
+              TARGET_PATH=$PROJECT
+              BASE=$(basename "$PROJECT" .xcodeproj)
+            fi
+
+            SCHEMES=$(xcodebuild "$TARGET_FLAG" "$TARGET_PATH" -list -json 2>/dev/null | jq -r '(.workspace // .project).schemes[]?' || true)
+            if [ -z "$SCHEMES" ]; then
+              SCHEMES=$(xcodebuild "$TARGET_FLAG" "$TARGET_PATH" -list 2>/dev/null | sed -n '/Schemes:/,$p' | tail -n +2 | sed 's/^[[:space:]]*//' | sed '/^$/d' || true)
+            fi
+            echo "Schemes:"
+            printf '%s\n' "$SCHEMES" | sed 's/^/  /'
+
+            # In a workspace, the scheme list also holds package and pod
+            # schemes, and they sort ahead of the app as often as not. The
+            # scheme named after the project is the app in nearly every repo.
+            SCHEME=$(printf '%s\n' "$SCHEMES" | grep -Fx "$BASE" | head -1 || true)
+            if [ -z "$SCHEME" ]; then
+              SCHEME=$(printf '%s\n' "$SCHEMES" | grep -v '^Pods-' | while IFS= read -r s; do
+                [ -n "$s" ] || continue
+                # A scheme that belongs to a local Swift package is not the app.
+                [ -z "$(find . -maxdepth 4 -path "*/$s/Package.swift" -print -quit)" ] || continue
+                printf '%s\n' "$s"
+                break
+              done)
             fi
             echo "Building with scheme: $SCHEME (configuration: $CONFIGURATION)"
           fi
@@ -451,8 +524,31 @@ jobs:
               # Flutter outputs to build/ios/iphoneos/
               APP_PATH=$(find "${GITHUB_WORKSPACE}/build/ios/iphoneos" -name "*.app" -type d | head -1)
             else
-              # Native and React Native/Expo use DerivedData
-              APP_PATH=$(find "$DERIVED_DATA_PATH/Build/Products/${CONFIGURATION}-iphoneos" -name "*.app" -type d | head -1)
+              # Native and React Native/Expo use DerivedData. Ask the project
+              # which bundle this scheme produces: the first .app under
+              # Build/Products is the wrong one whenever the repo has more than
+              # one app target.
+              if [ -n "$WORKSPACE" ]; then
+                TARGET_FLAG=-workspace
+                TARGET_PATH=$WORKSPACE
+              else
+                TARGET_FLAG=-project
+                TARGET_PATH=$PROJECT
+              fi
+              APP_PATH=$(xcodebuild "$TARGET_FLAG" "$TARGET_PATH" \
+                -scheme "$SCHEME" \
+                -configuration "$CONFIGURATION" \
+                -destination 'generic/platform=iOS' \
+                -derivedDataPath "$DERIVED_DATA_PATH" \
+                -showBuildSettings -json 2>/dev/null \
+                | jq -r 'map(.buildSettings)
+                         | map(select(.PRODUCT_TYPE == "com.apple.product-type.application"
+                                      and (.TARGET_BUILD_DIR | contains("-iphoneos"))))
+                         | map(.TARGET_BUILD_DIR + "/" + .FULL_PRODUCT_NAME)
+                         | first // empty' || true)
+              if [ ! -d "$APP_PATH" ]; then
+                APP_PATH=$(find "$DERIVED_DATA_PATH/Build/Products/${CONFIGURATION}-iphoneos" -maxdepth 1 -name "*.app" -type d -print -quit 2>/dev/null || true)
+              fi
             fi
 
             if [ -z "$APP_PATH" ]; then
@@ -470,16 +566,24 @@ jobs:
           fi
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ipa
           path: build/*.ipa
           retention-days: 7
           if-no-files-found: error
 
-      - name: Save DerivedData cache
-        uses: actions/cache/save@v4
+      # Flutter builds through its own tree, so DerivedData can be absent and a
+      # save would fail on a path that never existed.
+      - name: Check for DerivedData
+        id: dd
         if: always()
+        run: |
+          if [ -d DerivedData ]; then echo "exists=yes" >> $GITHUB_OUTPUT; fi
+
+      - name: Save DerivedData cache
+        uses: actions/cache/save@v6
+        if: always() && steps.dd.outputs.exists == 'yes'
         with:
           path: DerivedData
           key: deriveddata-${{ github.run_id }}

--- a/internal/workflow/templates/ios-share.yml
+++ b/internal/workflow/templates/ios-share.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # The dispatch always runs the workflow from the default branch, so the
       # sources come from a snapshot ref pushed by the CLI instead.
@@ -83,7 +83,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Restore DerivedData cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: DerivedData
           key: deriveddata-sim-${{ github.run_id }}
@@ -104,6 +104,28 @@ jobs:
           else
             echo "type=native" >> $GITHUB_OUTPUT
           fi
+
+      # A gitignored *.xcconfig next to a committed template is a common iOS
+      # convention. The snapshot then carries the template but not the config,
+      # and xcodebuild fails with "Unable to open base configuration reference
+      # file", which says nothing about which file is missing.
+      - name: Materialize missing xcconfig files
+        run: |
+          set -e
+          find . -path ./DerivedData -prune -o -type f \
+            \( -name '*.xcconfig.template' -o -name '*.xcconfig.example' \
+               -o -name '*.xcconfig.sample' -o -name '*.template.xcconfig' \
+               -o -name '*.example.xcconfig' -o -name '*.sample.xcconfig' \) -print \
+          | while IFS= read -r template; do
+              case "$template" in
+                *.xcconfig.template|*.xcconfig.example|*.xcconfig.sample) target="${template%.*}" ;;
+                *) target="$(dirname "$template")/$(basename "$template" | sed -E 's/\.(template|example|sample)\.xcconfig$/.xcconfig/')" ;;
+              esac
+              if [ ! -f "$target" ]; then
+                cp "$template" "$target"
+                echo "::warning::$target was missing (gitignored?); copied $template over it. Any placeholder values in it are what the build sees."
+              fi
+            done
 
       - name: Generate Xcode project (XcodeGen)
         env:
@@ -130,6 +152,35 @@ jobs:
             xcodegen generate
           fi
 
+      # Whatever the previous step could not fill in is named here, instead of
+      # surfacing as xcodebuild's "Unable to open base configuration reference".
+      - name: Check base configuration files
+        env:
+          IOS_PATH: ${{ inputs.ios_path }}
+        run: |
+          set -e
+          MISSING=""
+          for pbx in $(find "$IOS_PATH" -maxdepth 2 -name project.pbxproj -not -path '*/Pods.xcodeproj/*'); do
+            for id in $(grep -o 'baseConfigurationReference = [A-Za-z0-9]*' "$pbx" | awk '{print $3}' | sort -u); do
+              ref=$(grep -m1 "^[[:space:]]*$id .*isa = PBXFileReference" "$pbx" || true)
+              name=$(printf '%s' "$ref" | sed -n 's/.*[ \t]path = "\{0,1\}\([^";]*\)"\{0,1\};.*/\1/p')
+              [ -n "$name" ] || continue
+              base=$(basename "$name")
+              # CocoaPods writes its xcconfigs during pod install and Flutter
+              # writes Generated.xcconfig during pub get — both happen later in
+              # this job, so they are legitimately absent right now.
+              case "$name" in *Pods/*|*"Target Support Files"*) continue ;; esac
+              case "$base" in Pods-*|Generated.xcconfig) continue ;; esac
+              if [ -z "$(find . -name "$base" -print -quit)" ]; then
+                MISSING="$MISSING $base"
+              fi
+            done
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::The project has base configuration files that are not in the repository:$MISSING. They are probably gitignored — commit them, or commit a <name>.xcconfig.template next to each so the build can fill them in."
+            exit 1
+          fi
+
       - name: Setup Flutter
         if: steps.detect.outputs.type == 'flutter'
         uses: subosito/flutter-action@v2
@@ -144,7 +195,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.detect.outputs.type == 'reactnative' || steps.detect.outputs.type == 'expo'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -156,14 +207,14 @@ jobs:
       # script phase shells out to Gradle, which needs a JDK on PATH.
       - name: Setup JDK
         if: steps.detect.outputs.type == 'kmp'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: ${{ inputs.jdk_version || '17' }}
 
       - name: Setup Gradle
         if: steps.detect.outputs.type == 'kmp'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build for the simulator
         id: build
@@ -182,35 +233,94 @@ jobs:
           else
             cd "$IOS_PATH"
 
+            # CocoaPods generates the .xcworkspace and many repos gitignore it,
+            # so install before looking for one.
+            if [ -f Podfile ]; then
+              command -v pod >/dev/null 2>&1 || gem install cocoapods --no-document
+              pod install
+            fi
+
             WORKSPACE=$(find . -maxdepth 1 -name '*.xcworkspace' -print -quit)
             PROJECT=$(find . -maxdepth 1 -name '*.xcodeproj' -print -quit)
 
             if [ -n "$WORKSPACE" ]; then
-              [ -f Podfile ] && (gem install cocoapods --no-document >/dev/null 2>&1 || true) && pod install
-              TARGET_ARGS="-workspace $WORKSPACE"
-              LIST_ARGS="-workspace $WORKSPACE"
+              TARGET_FLAG=-workspace
+              TARGET_PATH=$WORKSPACE
+              BASE=$(basename "$WORKSPACE" .xcworkspace)
             elif [ -n "$PROJECT" ]; then
-              TARGET_ARGS="-project $PROJECT"
-              LIST_ARGS="-project $PROJECT"
+              TARGET_FLAG=-project
+              TARGET_PATH=$PROJECT
+              BASE=$(basename "$PROJECT" .xcodeproj)
             else
               echo "::error::No .xcworkspace or .xcodeproj found in $IOS_PATH"
               exit 1
             fi
 
             if [ -z "$SCHEME" ]; then
-              SCHEME=$(xcodebuild $LIST_ARGS -list 2>/dev/null | grep -A 100 "Schemes:" | tail -n +2 | grep -v -E "^[[:space:]]*Pods-" | head -1 | xargs)
+              SCHEMES=$(xcodebuild "$TARGET_FLAG" "$TARGET_PATH" -list -json 2>/dev/null | jq -r '(.workspace // .project).schemes[]?' || true)
+              if [ -z "$SCHEMES" ]; then
+                SCHEMES=$(xcodebuild "$TARGET_FLAG" "$TARGET_PATH" -list 2>/dev/null | sed -n '/Schemes:/,$p' | tail -n +2 | sed 's/^[[:space:]]*//' | sed '/^$/d' || true)
+              fi
+              echo "Schemes:"
+              printf '%s\n' "$SCHEMES" | sed 's/^/  /'
+
+              # In a workspace, the scheme list also holds package and pod
+              # schemes, and they sort ahead of the app as often as not. The
+              # scheme named after the project is the app in nearly every repo.
+              SCHEME=$(printf '%s\n' "$SCHEMES" | grep -Fx "$BASE" | head -1 || true)
+              if [ -z "$SCHEME" ]; then
+                SCHEME=$(printf '%s\n' "$SCHEMES" | grep -v '^Pods-' | while IFS= read -r s; do
+                  [ -n "$s" ] || continue
+                  # A scheme that belongs to a local Swift package is not the app.
+                  [ -z "$(find . -maxdepth 4 -path "*/$s/Package.swift" -print -quit)" ] || continue
+                  printf '%s\n' "$s"
+                  break
+                done)
+              fi
+            fi
+
+            if [ -z "$SCHEME" ]; then
+              echo "::error::Could not determine a scheme in $IOS_PATH. Pass one with the 'scheme' input."
+              exit 1
             fi
             echo "Scheme: $SCHEME"
 
-            xcodebuild $TARGET_ARGS \
+            # Build for the simulator this job is about to install on, rather
+            # than letting xcodebuild pick the first of several matches.
+            if [ -n "$MOBAI_SIM_UDID" ]; then
+              DEST_FLAG=-destination
+              DEST_VALUE="id=$MOBAI_SIM_UDID"
+            else
+              DEST_FLAG=-sdk
+              DEST_VALUE=iphonesimulator
+            fi
+
+            xcodebuild "$TARGET_FLAG" "$TARGET_PATH" \
               -scheme "$SCHEME" \
               -configuration Debug \
-              -sdk iphonesimulator \
+              "$DEST_FLAG" "$DEST_VALUE" \
               -derivedDataPath "$GITHUB_WORKSPACE/DerivedData" \
+              COMPILER_INDEX_STORE_ENABLE=NO \
               CODE_SIGNING_ALLOWED=NO \
               build
 
-            APP_PATH=$(find "$GITHUB_WORKSPACE/DerivedData/Build/Products" -maxdepth 2 -name '*.app' -print -quit)
+            # Ask the project which bundle this scheme produces: the first .app
+            # under Build/Products is the wrong one whenever the repo has more
+            # than one app target.
+            APP_PATH=$(xcodebuild "$TARGET_FLAG" "$TARGET_PATH" \
+              -scheme "$SCHEME" \
+              -configuration Debug \
+              "$DEST_FLAG" "$DEST_VALUE" \
+              -derivedDataPath "$GITHUB_WORKSPACE/DerivedData" \
+              -showBuildSettings -json 2>/dev/null \
+              | jq -r 'map(.buildSettings)
+                       | map(select(.PRODUCT_TYPE == "com.apple.product-type.application"
+                                    and (.TARGET_BUILD_DIR | contains("-iphonesimulator"))))
+                       | map(.TARGET_BUILD_DIR + "/" + .FULL_PRODUCT_NAME)
+                       | first // empty' || true)
+            if [ ! -d "$APP_PATH" ]; then
+              APP_PATH=$(find "$GITHUB_WORKSPACE/DerivedData/Build/Products/Debug-iphonesimulator" -maxdepth 1 -name '*.app' -print -quit 2>/dev/null || true)
+            fi
             cd "$GITHUB_WORKSPACE"
           fi
 
@@ -220,6 +330,24 @@ jobs:
           fi
           echo "Built $APP_PATH"
           echo "app_path=$APP_PATH" >> $GITHUB_OUTPUT
+
+      # Flutter builds through its own tree, so DerivedData can be absent and a
+      # save would fail on a path that never existed.
+      - name: Check for DerivedData
+        id: dd
+        if: always()
+        run: |
+          if [ -d DerivedData ]; then echo "exists=yes" >> $GITHUB_OUTPUT; fi
+
+      # Saved before the sharing step, which blocks for as long as the
+      # simulator is in use: a job that hits the timeout there would otherwise
+      # leave the next run with a cold DerivedData.
+      - name: Save DerivedData cache
+        if: always() && steps.dd.outputs.exists == 'yes'
+        uses: actions/cache/save@v6
+        with:
+          path: DerivedData
+          key: deriveddata-sim-${{ github.run_id }}
 
       # Installs the build on the simulator and publishes it to the MobAI app.
       # The step (and the job) stay running until the simulator is released


### PR DESCRIPTION
Review feedback on a build of a package-heavy repo (IceCubesApp) turned up several ways the generated workflows pick the wrong thing or fail opaquely. Fixed in both templates, since most of these applied equally to `ios-build.yml`.

### Real bugs

**`set -e` + Podfile probe killed workspace builds** — `[ -f Podfile ] && (gem install …) && pod install` returns 1 when there is no Podfile, which exits the whole step. Any `.xcworkspace` project without CocoaPods (anything SPM-based) died there. It is a proper `if` now, and it runs *before* workspace detection: CocoaPods generates the `.xcworkspace` and many repos gitignore it, so looking first found nothing to build.

**DerivedData was never saved** — `ios-share.yml` had `cache/restore` and no `cache/save`, so the cache could only ever miss and every build was cold. The save now runs *before* the sharing step, which blocks until the simulator session ends or the job times out. Both templates guard the save on the directory existing: Flutter builds never create `DerivedData`, and `cache/save` fails on a path that was never there.

**No `-destination` on the booted simulator** — the build passed only `-sdk iphonesimulator`, producing `WARNING: Using the first of multiple matching destinations`. It now targets the simulator it is about to install on: `-destination "id=$MOBAI_SIM_UDID"`, falling back to `-sdk` when no UDID is set.

**Fragile scheme auto-detection** — `xcodebuild -list | grep -A 100 "Schemes:" | tail -n +2 | head -1` takes the first scheme, which in a package-heavy repo is often a package scheme rather than the app, and `-A 100` truncates on projects with many schemes. It now reads `-list -json`, prefers the scheme named after the workspace/project, and otherwise takes the first that is neither `Pods-*` nor a local Swift package's. It prints the candidates it saw and errors telling you to pass `scheme` when it cannot decide.

**`.app` selection could pick the wrong bundle** — `find … -maxdepth 2 -name '*.app' -print -quit` takes whatever comes first. The product now comes from `-showBuildSettings -json`: the target whose `PRODUCT_TYPE` is an application. Matching on the scheme name would not do — product names routinely differ from scheme names.

**Gitignored `.xcconfig` with a committed template** — a common iOS convention that failed as an opaque `Unable to open base configuration reference file`. `*.xcconfig.{template,example,sample}` and `*.{template,example,sample}.xcconfig` are now copied into place with a warning naming the file, and anything still referenced by the project and missing fails the job **by name**. CocoaPods and Flutter-generated configs are skipped — those are written later in the same job.

**Deprecated action versions** — checkout v4→v7, cache v4→v6, upload-artifact v4→v7, setup-node v4→v7, setup-java v4→v6, setup-gradle v4→v6. The v4 versions target Node 20 and the runner already warns it is forcing them onto Node 24. The checkout v6/v7 breaking changes concern fork-PR checkout under `pull_request_target`, which does not apply to `workflow_dispatch`.

### Verification

- Both templates parse as YAML and every `run` block passes `bash -n`.
- The materialization, pbxproj scan and scheme-picking blocks were run against fixtures (missing vs. present configs, both template suffix orders, Pods exclusion, package-only scheme lists).
- An XcodeGen fixture with two app targets plus a local Swift package built on a booted simulator with Xcode 26.6: the old logic picks scheme `AAAFirstThing`, the new logic picks `Fixture` and resolves its real product `Ice Cubes.app`. Device-destination resolution checked the same way.
- `go build ./...` and `go test ./...` pass.

Note these take effect for a repo only once the templates are on its default branch — dispatch reads the workflow from there.